### PR TITLE
Extend CMakeLists file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 IF(UNIX)
   # add some standard warnings
   ADD_DEFINITIONS(-Wno-variadic-macros -Wno-long-long -Wall -Wextra -Winit-self -Woverloaded-virtual -Wsign-promo -Wno-unused-parameter -pedantic -Woverloaded-virtual -Wno-unknown-pragmas)
-  
+
   # -ansi does not compile with sjn module
   #ADD_DEFINITIONS(-ansi)
 
@@ -17,6 +17,7 @@ IF(UNIX)
 endif(UNIX)
 
 find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
 
 if(${OpenCV_VERSION} VERSION_LESS 2.3.1)
   message (FATAL_ERROR "OpenCV version is not compatible: ${OpenCV_VERSION}")


### PR DESCRIPTION
I got issues with compiling BGSLibrary using `cmake` with following error:
```
(...)/bgslibrary/package_bgs/jmo/BlobExtraction.cpp:74:10: fatal error:
      'cv.h' file not found
#include <cv.h>
```
It may be somehow connected to fact that I compiled OpenCV only for shared libs, not static. However, after adding `include_directories` to `CMakeLists.txt` I compiled the lib with success. I assume that it will not break compile process in other environments, as it is officially supported in `OpenCVConfig.cmake`.

I am using Mac OS X Yosemite.