### PR TITLE
Restore MultiLayerBGS with OpenCV 3.1 compatibility

### DIFF
--- a/package_bgs/jmo/BGS.h
+++ b/package_bgs/jmo/BGS.h
@@ -1,0 +1,216 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#if !defined(_BGS_H_)
+#define _BGS_H_
+
+#include "OpenCvLegacyIncludes.h"
+
+
+// TODO check these defines are not used (or not redundant with real params)
+#define MAX_LBP_MODE_NUM	5
+
+#define ROBUST_COLOR_OFFSET	6.0f
+
+#define LOW_INITIAL_MODE_WEIGHT	0.01f
+
+#define MODE_UPDATING_LEARN_RATE	0.01f
+#define WEIGHT_UPDATING_LEARN_RATE	0.01f
+
+#define COLOR_MAX_MIN_OFFSET		5
+
+#define BACKGROUND_MODEL_PERCENT	0.6f
+
+#define PATTERN_COLOR_DIST_BACKGROUND_THRESHOLD	0.2f
+
+#define PATTERN_DIST_SMOOTH_NEIG_HALF_SIZE	6
+#define PATTERN_DIST_CONV_GAUSSIAN_SIGMA	2.5f
+
+#define ROBUST_SHADOW_RATE	0.6f
+#define ROBUST_HIGHLIGHT_RATE	1.20f
+
+#define BINARY_PATTERM_ELEM(c1, c2, offset)	\
+  ((float)(c2)-(float)(c1)+offset > 0)
+
+/*
+#define BINARY_PATTERM_ELEM(c1, c2, offset)	\
+( fabsf((float)(c2)-(float)(c1)) <= offset ? 1 : (float)(c2)-(float)(c1) >=0 )
+*/
+
+#ifndef PI
+#define PI 3.141592653589793f
+#endif
+
+/************************************************************************/
+/* some data structures for multi-level LBP (local binary pattern)      */
+/* texture feature for background subtraction                           */
+/************************************************************************/
+typedef struct _LBP
+{
+  float* bg_pattern;			/* the average local binary pattern of background mode */
+  float* bg_intensity;			/* the average color intensity of background mode */
+  float* max_intensity;			/* the maximal color intensity of background mode */
+  float* min_intensity;			/* the minimal color intensity of background mode */
+  float weight;				/* the weight of background mode, i.e. probability that the background mode belongs to background */
+  float max_weight;			/* the maximal weight of background mode */
+  int bg_layer_num;			/* the background layer number of background mode */
+  unsigned long first_time;				/* the first time of background mode appearing */
+  unsigned long last_time;				/* the last time of background model appearing */
+  int freq;				/* the appearing frequency */
+  //long mnrl;				/* maximum negative run-length */
+  unsigned long layer_time;				/* the first time of background mode becoming a background layer */
+}
+LBPStruct;
+
+typedef struct _PixelLBP
+{
+  LBPStruct* LBPs;			/* the background modes */
+  unsigned short* lbp_idxes;		/* the indices of background modes */
+  unsigned int cur_bg_layer_no;
+  unsigned int num;			/* the total number of background modes */
+  unsigned int bg_num;			/* the number of the first background modes for foreground detection */
+  unsigned char* cur_intensity;		/* the color intensity of current pixel */
+  float* cur_pattern;			/* the local binary pattern of current pixel */
+  float matched_mode_first_time;		/* the index of currently matched pixel mode */
+}
+PixelLBPStruct;
+
+/*********************************************************************************/
+/* should replace the above structure using class in the future (not finished)   */
+/*********************************************************************************/
+
+class BG_PIXEL_MODE
+{
+public:
+  float* bg_lbp_pattern;			/* the average local binary pattern of background mode */
+  float* bg_intensity;			/* the average color intensity of background mode */
+  float* max_intensity;			/* the maximal color intensity of background mode */
+  float* min_intensity;			/* the minimal color intensity of background mode */
+  float weight;				/* the weight of background mode, i.e. probability that the background mode belongs to background */
+  float max_weight;			/* the maximal weight of background mode */
+  int bg_layer_num;			/* the background layer number of background mode */
+
+  int lbp_pattern_length;
+  int color_channel;
+
+  BG_PIXEL_MODE(int _lbp_pattern_length, int _color_channel = 3) {
+    lbp_pattern_length = _lbp_pattern_length;
+    color_channel = _color_channel;
+
+    bg_lbp_pattern = new float[lbp_pattern_length];
+    bg_intensity = new float[color_channel];
+    max_intensity = new float[color_channel];
+    min_intensity = new float[color_channel];
+  };
+
+  virtual ~BG_PIXEL_MODE() {
+    delete[] bg_lbp_pattern;
+    delete[] bg_intensity;
+    delete[] max_intensity;
+    delete[] min_intensity;
+  };
+};
+
+class BG_PIXEL_PATTERN
+{
+public:
+  BG_PIXEL_MODE** pixel_MODEs;		/* the background modes */
+  unsigned short* lbp_pattern_idxes;	/* the indices of background modes */
+  unsigned int cur_bg_layer_no;
+  unsigned int num;			/* the total number of background modes */
+  unsigned int bg_num;			/* the number of the first background modes for foreground detection */
+  unsigned char* cur_intensity;		/* the color intensity of current pixel */
+  float* cur_lbp_pattern;			/* the local binary pattern of current pixel */
+
+  int lbp_pattern_length;
+  int color_channel;
+  int pixel_mode_num;
+
+  BG_PIXEL_PATTERN(int _pixel_mode_num, int _lbp_pattern_length, int _color_channel = 3) {
+    pixel_mode_num = _pixel_mode_num;
+    lbp_pattern_length = _lbp_pattern_length;
+    color_channel = _color_channel;
+
+    pixel_MODEs = new BG_PIXEL_MODE*[pixel_mode_num];
+
+    for (int i = 0; i < pixel_mode_num; i++) {
+      pixel_MODEs[i] = new BG_PIXEL_MODE(_lbp_pattern_length, _color_channel);
+    }
+
+    lbp_pattern_idxes = new unsigned short[pixel_mode_num];
+    cur_intensity = new unsigned char[color_channel];
+    cur_lbp_pattern = new float[lbp_pattern_length];
+  };
+
+  virtual ~BG_PIXEL_PATTERN() {
+    delete[] lbp_pattern_idxes;
+    delete[] cur_intensity;
+    delete[] cur_lbp_pattern;
+
+    for (int i = 0; i < pixel_mode_num; i++)
+      delete pixel_MODEs[i];
+    delete[] pixel_MODEs;
+  };
+};
+
+class IMAGE_BG_MODEL
+{
+  int pixel_length;
+
+  BG_PIXEL_PATTERN** pixel_PATTERNs;
+
+  IMAGE_BG_MODEL(int _pixel_length, int _pixel_mode_num, int _lbp_pattern_length, int _color_channel = 3) {
+    pixel_length = _pixel_length;
+
+    pixel_PATTERNs = new BG_PIXEL_PATTERN*[pixel_length];
+    for (int i = 0; i < pixel_length; i++)
+      pixel_PATTERNs[i] = new BG_PIXEL_PATTERN(_pixel_mode_num, _lbp_pattern_length, _color_channel);
+  }
+  virtual ~IMAGE_BG_MODEL() {
+    for (int i = 0; i < pixel_length; i++)
+      delete pixel_PATTERNs[i];
+    delete[] pixel_PATTERNs;
+  }
+};
+
+
+#endif // !defined(_BGS_H_)

--- a/package_bgs/jmo/BackgroundSubtractionAPI.h
+++ b/package_bgs/jmo/BackgroundSubtractionAPI.h
@@ -1,0 +1,158 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+//////////////////////////////////////////////////////////////////////
+//
+// BackgroundSubtractionAPI.h: 
+//   interface for the BackgroundSubtractionAPI class.
+//
+// A background subtraction algorithm takes as input
+// an RGB image and provide as ouput a Binary mask
+// with a value of 0 for points belonging to the 
+// background, and non zero for points belonging
+// to the foreground.
+//
+//
+//
+// To add:
+//  - a function indicating the valid input and ouput
+//    images 
+//     e.g. RGB  image (default) or greylevel image for the input
+//          char image for the output
+//
+//////////////////////////////////////////////////////////////////////
+
+
+#if !defined(_BACKGROUND_SUBTRACTION_API_H_)
+#define _BACKGROUND_SUBTRACTION_API_H_
+
+#include "OpenCvLegacyIncludes.h"
+
+class CBackgroundSubtractionAPI
+{
+public:
+  //CBackgroundSubtractionAPI(){};
+  //virtual ~CBackgroundSubtractionAPI(){};
+
+  //-------------------------------------------------------------
+  // TO CALL AT INITIALISATION: DEFINES THE SIZE OF THE INPUT IMAGES
+  // NORMALLY, UNNECESSARY IF A CONFIGURATION FILE IS LOADED
+  void   Init(int width, int height);
+
+  //-------------------------------------------------------------
+  // PROVIDE A MASK TO DEFINE THE SET OF POINTS WHERE BACKGROUND 
+  // SUBTRACTION DOES NOT NEED TO BE PERFORMED
+  // 
+  //  mode is useful to specify if the points to remove from 
+  //  processing are in addition to the ones potentially
+  //  removed according to the configuration file,
+  //  or if they are the only ones to be removed 
+  // 
+  // mode=0 : provided points need to be removed
+  //          in addition to those already removed
+  // mode=1 : the provided points are the only one to remove
+  //          from processing
+  // Note:  maskImage(li,co)=0 indicate the points to remove
+  //       from background processing
+  void   SetValidPointMask(IplImage* maskImage, int mode);
+
+  //-------------------------------------------------------------
+  // 
+  //   set the frame rate, to adjust the update parameters
+  //   to the actual frame rate.
+  //   Can be called only once at initialisation,
+  //   but in online cases, can be used to indicate
+  //   the time interval during the last processed frame 
+  //
+  //   frameDuration is in millisecond
+  void   SetFrameRate(float    frameDuration);
+
+  //-------------------------------------------------------------
+  //   PROVIDE A POINTER TO THE INPUT IMAGE
+  //   -> INDICATE WHERE THE NEW IMAGE TO PROCESS IS STORED
+  //
+  //   Here assumes that the input image will contain RGB images.
+  //   The memory of this image is handled by the caller.
+  //
+  //    The return value indicate whether the actual Background 
+  //    Subtraction algorithm handles RGB images (1) or not (0).
+  //   
+  int  SetRGBInputImage(IplImage  *  inputImage);
+
+  //-------------------------------------------------------------
+  //   PROVIDE A POINTER TO THE RESULT IMAGE
+  //   INDICATE WHERE THE BACKGROUND RESULT NEED TO BE STORED
+  //  
+  //   The return value is 1 if correct image format is provided,
+  //   otherwise the return value is 0.
+  //   e.g. fg_mask_img = cvCreateImage(imgSize, IPL_DEPTH_8U, 1);
+  int  SetForegroundMaskImage(IplImage *fg_mask_img);
+
+  //   The return value is 1 if the function is implemented 
+  //   with correct format, otherwise the return value is 0
+  //   e.g. fg_prob_img = cvCreateImage(imgSize, IPL_DEPTH_32F, 1);
+  int  SetForegroundProbImage(IplImage *fg_prob_img);
+
+  //-------------------------------------------------------------
+  // This function should be called each time a new image is 
+  // available in the input image.
+  // 
+  // The return value is 1 if everything goes well,
+  // otherwise the return value is 0.  
+  //
+  int   Process();
+
+  //-------------------------------------------------------------
+  // this function should save parameters and information of the model
+  // (e.g. after a training of the model, or in such a way
+  // that the model can be reload to process the next frame
+  // type of save:
+  void   Save(char   *bg_model_fn);
+
+  //-------------------------------------------------------------
+  // this function should load the parameters necessary
+  // for the processing of the background subtraction or 
+  // load background model information
+  void   Load(char  *bg_model_fn);
+};
+
+#endif // !defined(_BACKGROUND_SUBTRACTION_API_H_)

--- a/package_bgs/jmo/BlobExtraction.cpp
+++ b/package_bgs/jmo/BlobExtraction.cpp
@@ -1,0 +1,1496 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+//***********************************************************//
+//* Blob analysis package  8 August 2003                    *//
+//* Version 1.0                                             *//
+//* Input: IplImage* binary image                           *//
+//* Output: attributes of each connected region             *//
+//* Author: Dave Grossman                                   *//
+//* Modifications: Francesc Pinyol and Ricard Borras		*//
+//* Email: dgrossman@cdr.stanford.edu                       *//
+//* Email: fpinyol@cvc.uab.es rborras@cvc.uab.es            *//
+//* Acknowledgement: the algorithm has been around > 20 yrs *//
+//***********************************************************//
+
+//! Indica si la connectivitat es a 8 (si es desactiva es a 4)
+#define B_CONNECTIVITAT_8
+
+//! si la imatge és cíclica verticalment (els blobs que toquen
+//! les vores superior i inferior no es consideren externs)
+#define IMATGE_CICLICA_VERTICAL		1
+//! si la imatge és cíclica horitzontalment (els blobs que toquen
+//! les vores dreta i esquerra no es consideren externs)
+#define IMATGE_CICLICA_HORITZONTAL	0
+
+#define PERIMETRE_DIAGONAL (1.41421356237310 - 2)
+#define SQRT2	1.41421356237310
+// color dels píxels de la màscara per ser exteriors
+#define PIXEL_EXTERIOR 0
+
+
+#include "BlobResult.h"
+#include "BlobExtraction.h"
+#include "OpenCvLegacyIncludes.h"
+
+namespace Blob
+{
+
+  /**
+  - FUNCIÓ: BlobAnalysis
+  - FUNCIONALITAT: Extreu els blobs d'una imatge d'un sol canal
+  - PARÀMETRES:
+  - inputImage: Imatge d'entrada. Ha de ser d'un sol canal
+  - threshold: Nivell de gris per considerar un pixel blanc o negre
+  - maskImage: Imatge de màscara fora de la cual no es calculen els blobs. A més,
+  els blobs que toquen els pixels de la màscara a 0, són considerats
+  externs
+  - borderColor: Color del marc de la imatge (0=black or 1=white)
+  - findmoments: calcula els moments dels blobs o no
+  - RegionData: on es desarà el resultat
+  - RESULTAT:
+  - retorna true si tot ha anat bé, false si no. Deixa el resultat a blobs.
+  - RESTRICCIONS:
+  - La imatge d'entrada ha de ser d'un sol canal
+  - AUTOR: dgrossman@cdr.stanford.edu
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  - fpinyol@cvc.uab.es, rborras@cvc.uab.es: adaptació a les OpenCV
+  */
+  bool BlobAnalysis(IplImage* inputImage,
+    uchar threshold,
+    IplImage* maskImage,
+    bool borderColor,
+    bool findmoments,
+    blob_vector &RegionData)
+  {
+    // dimensions of input image taking in account the ROI
+    int Cols, Rows, startCol, startRow;
+
+    if (inputImage->roi)
+    {
+      CvRect imageRoi = cvGetImageROI(inputImage);
+      startCol = imageRoi.x;
+      startRow = imageRoi.y;
+      Cols = imageRoi.width;
+      Rows = imageRoi.height;
+    }
+    else
+    {
+      startCol = 0;
+      startRow = 0;
+      Cols = inputImage->width;
+      Rows = inputImage->height;
+    }
+
+    int Trans = Cols;				// MAX trans in any row
+    char* pMask = NULL;
+    char* pImage;
+
+    // Convert image array into transition array. In each row
+    // the transition array tells which columns have a color change
+    int iCol, iRow, iTran, Tran;				// Data for a given run
+    bool ThisCell, LastCell;		// Contents (colors (0 or 1)) within this row
+    int TransitionOffset = 0;		// Performance booster to avoid multiplication
+
+    // row 0 and row Rows+1 represent the border
+    int i;
+    int *Transition;				// Transition Matrix
+
+    int nombre_pixels_mascara = 0;
+    //! Imatge amb el perimetre extern de cada pixel
+    IplImage *imatgePerimetreExtern;
+
+    // input images must have only 1-channel and be an image
+    if (!CV_IS_IMAGE(inputImage) || (inputImage->nChannels != 1))
+    {
+      return false;
+    }
+    if (maskImage != NULL)
+    {
+      // input image and mask are a valid image?
+      if (!CV_IS_IMAGE(inputImage) || !CV_IS_IMAGE(maskImage))
+        return false;
+
+      // comprova que la màscara tingui les mateixes dimensions que la imatge
+      if (inputImage->width != maskImage->width || inputImage->height != maskImage->height)
+      {
+        return false;
+      }
+
+      // comprova que la màscara sigui una imatge d'un sol canal (grayscale)
+      if (maskImage->nChannels != 1)
+      {
+        return false;
+      }
+
+    }
+
+    // Initialize Transition array
+    Transition = new int[(Rows + 2)*(Cols + 2)];
+    memset(Transition, 0, (Rows + 2) * (Cols + 2)*sizeof(int));
+    Transition[0] = Transition[(Rows + 1) * (Cols + 2)] = Cols + 2;
+
+    // Start at the beginning of the image (startCol, startRow)
+    pImage = inputImage->imageData + startCol - 1 + startRow * inputImage->widthStep;
+
+    /*
+    Paral·lelització del càlcul de la matriu de transicions
+    Fem que cada iteració del for el faci un thread o l'altre ( tenim 2 possibles threads )
+    */
+    if (maskImage == NULL)
+    {
+      imatgePerimetreExtern = NULL;
+
+      //Fill Transition array
+      for (iRow = 1; iRow < Rows + 1; iRow++)		// Choose a row of Bordered image
+      {
+        TransitionOffset = iRow*(Cols + 2); //per a que sigui paral·litzable
+        iTran = 0;					// Index into Transition array
+        Tran = 0;					// No transitions at row start
+        LastCell = borderColor;
+
+        for (iCol = 0; iCol < Cols + 2; iCol++)	// Scan that row of Bordered image
+        {
+          if (iCol == 0 || iCol == Cols + 1)
+            ThisCell = borderColor;
+          else
+            ThisCell = ((unsigned char)*(pImage)) > threshold;
+
+          if (ThisCell != LastCell)
+          {
+            Transition[TransitionOffset + iTran] = Tran;	// Save completed Tran
+            iTran++;						// Prepare new index
+            LastCell = ThisCell;			// With this color
+          }
+
+          Tran++;	// Tran continues
+          pImage++;
+        }
+
+        Transition[TransitionOffset + iTran] = Tran;	// Save completed run
+        if ((TransitionOffset + iTran + 1) < (Rows + 1)*(Cols + 2))
+        {
+          Transition[TransitionOffset + iTran + 1] = -1;
+        }
+        //jump to next row (beginning from (startCol, startRow))
+        pImage = inputImage->imageData - 1 + startCol + (iRow + startRow)*inputImage->widthStep;
+      }
+    }
+    else
+    {
+      //maskImage not NULL: Cal recòrrer la màscara també per calcular la matriu de transicions
+
+      char perimeter;
+      char *pPerimetre;
+
+      // creem la imatge que contindrà el perimetre extern de cada pixel
+      imatgePerimetreExtern = cvCreateImage(cvSize(maskImage->width, maskImage->height), IPL_DEPTH_8U, 1);
+      cvSetZero(imatgePerimetreExtern);
+
+      pMask = maskImage->imageData - 1;
+
+      //Fill Transition array
+      for (iRow = 1; iRow < Rows + 1; iRow++)		// Choose a row of Bordered image
+      {
+        TransitionOffset = iRow*(Cols + 2);
+        iTran = 0;					// Index into Transition array
+        Tran = 0;					// No transitions at row start
+        LastCell = borderColor;
+
+        pPerimetre = imatgePerimetreExtern->imageData + (iRow - 1) * imatgePerimetreExtern->widthStep;
+        //pMask = maskImage->imageData + (iRow-1) * maskImage->widthStep;
+
+        for (iCol = 0; iCol < Cols + 2; iCol++)	// Scan that row of Bordered image
+        {
+          if (iCol == 0 || iCol == Cols + 1 || ((unsigned char)*pMask) == PIXEL_EXTERIOR)
+            ThisCell = borderColor;
+          else
+            ThisCell = ((unsigned char)*(pImage)) > threshold;
+
+          if (ThisCell != LastCell)
+          {
+            Transition[TransitionOffset + iTran] = Tran;	// Save completed Tran
+            iTran++;						// Prepare new index
+            LastCell = ThisCell;			// With this color
+          }
+
+          /*////////////////////////////////////////////////////////////////////////
+          Calcul de la imatge amb els pixels externs
+          ////////////////////////////////////////////////////////////////////////*/
+          // pels pixels externs no cal calcular res pq no hi accedir-hem
+          if ((iCol > 0) && (iCol < Cols))
+          {
+            if (*pMask == PIXEL_EXTERIOR)
+            {
+              *pPerimetre = 0;
+            }
+            else
+            {
+              perimeter = 0;
+
+              // pixels al nord de l'actual
+              if (iRow > 1)
+              {
+                if (*(pMask - maskImage->widthStep) == PIXEL_EXTERIOR) perimeter++;
+              }
+
+              // pixels a l'est i oest de l'actual
+              if (iRow < imatgePerimetreExtern->height)
+              {
+                if ((iCol>0) && (*(pMask - 1) == PIXEL_EXTERIOR)) perimeter++;
+
+                if ((iCol < imatgePerimetreExtern->width - 1) && (*(pMask + 1) == PIXEL_EXTERIOR)) perimeter++;
+              }
+
+              // pixels al sud de l'actual
+              if (iRow < imatgePerimetreExtern->height - 1)
+              {
+                if ((*(pMask + maskImage->widthStep) == PIXEL_EXTERIOR)) perimeter++;
+              }
+
+              *pPerimetre = perimeter;
+            }
+          }
+
+          Tran++;	// Tran continues
+          pImage++;
+          pMask++;
+          pPerimetre++;
+        }
+        Transition[TransitionOffset + iTran] = Tran;	// Save completed run
+
+        if ((TransitionOffset + iTran + 1) < (Rows + 1)*(Cols + 2))
+        {
+          Transition[TransitionOffset + iTran + 1] = -1;
+        }
+
+
+        //jump to next row (beginning from (startCol, startRow))
+        pImage = inputImage->imageData - 1 + startCol + (iRow + startRow)*inputImage->widthStep;
+        //the mask should be the same size as image Roi, so don't take into account the offset
+        pMask = maskImage->imageData - 1 + iRow*maskImage->widthStep;
+      }
+    }
+
+    // Process transition code depending on Last row and This row
+    //
+    // Last ---++++++--+++++++++++++++-----+++++++++++++++++++-----++++++-------+++---
+    // This -----+++-----++++----+++++++++----+++++++---++------------------++++++++--
+    //
+    // There are various possibilities:
+    //
+    // Case     1       2       3       4       5       6       7       8
+    // Last |xxx    |xxxxoo |xxxxxxx|xxxxxxx|ooxxxxx|ooxxx  |ooxxxxx|    xxx|
+    // This |    yyy|    yyy|  yyyy |  yyyyy|yyyyyyy|yyyyyyy|yyyy   |yyyy   |
+    // Here o is optional
+    // 
+    // Here are the primitive tests to distinguish these 6 cases:
+    //   A) Last end < This start - 1 OR NOT		Note: -1
+    //   B) This end < Last start OR NOT
+    //   C) Last start < This start OR NOT
+    //   D) This end < Last end OR NOT
+    //   E) This end = Last end OR NOT
+    //
+    // Here is how to use these tests to determine the case:
+    //   Case 1 = A [=> NOT B AND C AND NOT D AND NOT E]
+    //   Case 2 = C AND NOT D AND NOT E [AND NOT A AND NOT B]
+    //   Case 3 = C AND D [=> NOT E] [AND NOT A AND NOT B]
+    //   Case 4 = C AND NOT D AND E [AND NOT A AND NOT B]
+    //   Case 5 = NOT C AND E [=> NOT D] [AND NOT A AND NOT B]
+    //   Case 6 = NOT C AND NOT D AND NOT E [AND NOT A AND NOT B]
+    //   Case 7 = NOT C AND D [=> NOT E] [AND NOT A AND NOT B]
+    //   Case 8 = B [=> NOT A AND NOT C AND D AND NOT E]
+    //
+    // In cases 2,3,4,5,6,7 the following additional test is needed:
+    //   Match) This color = Last color OR NOT
+    //
+    // In cases 5,6,7 the following additional test is needed:
+    //   Known) This region was already matched OR NOT
+    //
+    // Here are the main tests and actions:
+    //   Case 1: LastIndex++;
+    //   Case 2: if(Match) {y = x;}
+    //           LastIndex++;
+    //   Case 3: if(Match) {y = x;}
+    //           else {y = new}
+    //           ThisIndex++;
+    //   Case 4: if(Match) {y = x;}
+    //           else {y = new}
+    //           LastIndex++;
+    //           ThisIndex++;
+    //   Case 5: if(Match AND NOT Known) {y = x}
+    //           else if(Match AND Known) {Subsume(x,y)}
+    //           LastIndex++;ThisIndex++
+    //   Case 6: if(Match AND NOT Known) {y = x}
+    //           else if(Match AND Known) {Subsume(x,y)}
+    //           LastIndex++;
+    //   Case 7: if(Match AND NOT Known) {y = x}
+    //           else if(Match AND Known) {Subsume(x,y)}
+    //           ThisIndex++;
+    //   Case 8: ThisIndex++;
+
+    int *SubsumedRegion = NULL;
+
+    double ThisParent;	// These data can change when the line is current
+    double ThisArea;
+    double ThisPerimeter;
+    double ThisSumX = 0;
+    double ThisSumY = 0;
+    double ThisSumXX = 0;
+    double ThisSumYY = 0;
+    double ThisSumXY = 0;
+    double ThisMinX;
+    double ThisMaxX;
+    double ThisMinY;
+    double ThisMaxY;
+    double LastPerimeter;	// This is the only data for retroactive change
+    double ThisExternPerimeter;
+
+    int HighRegionNum = 0;
+    //int RegionNum = 0;
+    int ErrorFlag = 0;
+
+    int LastRow, ThisRow;			// Row number
+    int LastStart, ThisStart;		// Starting column of run
+    int LastEnd, ThisEnd;			// Ending column of run
+    int LastColor, ThisColor;		// Color of run
+
+    int LastIndex, ThisIndex;		// Which run are we up to
+    int LastIndexCount, ThisIndexCount;	// Out of these runs
+    int LastRegionNum, ThisRegionNum;	// Which assignment
+    int *LastRegion;				// Row assignment of region number
+    int *ThisRegion;		// Row assignment of region number
+
+    int LastOffset = -(Trans + 2);	// For performance to avoid multiplication
+    int ThisOffset = 0;				// For performance to avoid multiplication
+    int ComputeData;
+
+    CvPoint actualedge;
+    uchar imagevalue;
+    bool CandidatExterior = false;
+
+    // apuntadors als blobs de la regió actual i last
+    CBlob *regionDataThisRegion, *regionDataLastRegion;
+
+    LastRegion = new int[Cols + 2];
+    ThisRegion = new int[Cols + 2];
+
+    for (i = 0; i < Cols + 2; i++)	// Initialize result arrays
+    {
+      LastRegion[i] = -1;
+      ThisRegion[i] = -1;
+    }
+
+    //create the external blob
+    RegionData.push_back(new CBlob());
+    SubsumedRegion = NewSubsume(SubsumedRegion, 0);
+    RegionData[0]->parent = -1;
+    RegionData[0]->area = (double)Transition[0];
+    RegionData[0]->perimeter = (double)(2 + 2 * Transition[0]);
+
+    ThisIndexCount = 1;
+    ThisRegion[0] = 0;	// Border region
+
+    // beginning of the image 
+    // en cada linia, pimage apunta al primer pixel de la fila
+    pImage = inputImage->imageData - 1 + startCol + startRow * inputImage->widthStep;
+    //the mask should be the same size as image Roi, so don't take into account the offset
+    if (maskImage != NULL) pMask = maskImage->imageData - 1;
+
+    char *pImageAux, *pMaskAux = NULL;
+
+    // Loop over all rows
+    for (ThisRow = 1; ThisRow < Rows + 2; ThisRow++)
+    {
+      //cout << "========= THIS ROW = " << ThisRow << endl;	// for debugging
+      ThisOffset += Trans + 2;
+      ThisIndex = 0;
+      LastOffset += Trans + 2;;
+      LastRow = ThisRow - 1;
+      LastIndexCount = ThisIndexCount;
+      LastIndex = 0;
+
+      int EndLast = 0;
+      int EndThis = 0;
+
+      for (int j = 0; j < Trans + 2; j++)
+      {
+        int Index = ThisOffset + j;
+        int TranVal = Transition[Index];
+        if (TranVal > 0) ThisIndexCount = j + 1;	// stop at highest 
+
+        if (ThisRegion[j] == -1)  { EndLast = 1; }
+        if (TranVal < 0) { EndThis = 1; }
+
+        if (EndLast > 0 && EndThis > 0) { break; }
+
+        LastRegion[j] = ThisRegion[j];
+        ThisRegion[j] = -1;		// Flag indicates region is not initialized
+      }
+
+      int MaxIndexCount = LastIndexCount;
+      if (ThisIndexCount > MaxIndexCount) MaxIndexCount = ThisIndexCount;
+
+      // Main loop over runs within Last and This rows
+      while (LastIndex < LastIndexCount && ThisIndex < ThisIndexCount)
+      {
+        ComputeData = 0;
+
+        if (LastIndex == 0) LastStart = 0;
+        else LastStart = Transition[LastOffset + LastIndex - 1];
+        LastEnd = Transition[LastOffset + LastIndex] - 1;
+        LastColor = LastIndex - 2 * (LastIndex / 2);
+        LastRegionNum = LastRegion[LastIndex];
+
+        regionDataLastRegion = RegionData[LastRegionNum];
+
+
+        if (ThisIndex == 0) ThisStart = 0;
+        else ThisStart = Transition[ThisOffset + ThisIndex - 1];
+        ThisEnd = Transition[ThisOffset + ThisIndex] - 1;
+        ThisColor = ThisIndex - 2 * (ThisIndex / 2);
+        ThisRegionNum = ThisRegion[ThisIndex];
+
+        if (ThisRegionNum >= 0)
+          regionDataThisRegion = RegionData[ThisRegionNum];
+        else
+          regionDataThisRegion = NULL;
+
+
+        // blobs externs
+        CandidatExterior = false;
+        if (
+#if !IMATGE_CICLICA_VERTICAL
+          ThisRow == 1 || ThisRow == Rows ||
+#endif
+#if !IMATGE_CICLICA_HORITZONTAL
+          ThisStart <= 1 || ThisEnd >= Cols ||
+#endif				
+          GetExternPerimeter(ThisStart, ThisEnd, ThisRow, inputImage->width, inputImage->height, imatgePerimetreExtern)
+          )
+        {
+          CandidatExterior = true;
+        }
+
+        int TestA = (LastEnd < ThisStart - 1);	// initially false
+        int TestB = (ThisEnd < LastStart);		// initially false
+        int TestC = (LastStart < ThisStart);	// initially false
+        int TestD = (ThisEnd < LastEnd);
+        int TestE = (ThisEnd == LastEnd);
+
+        int TestMatch = (ThisColor == LastColor);		// initially true
+        int TestKnown = (ThisRegion[ThisIndex] >= 0);	// initially false
+
+        int Case = 0;
+        if (TestA) Case = 1;
+        else if (TestB) Case = 8;
+        else if (TestC)
+        {
+          if (TestD) Case = 3;
+          else if (!TestE) Case = 2;
+          else Case = 4;
+        }
+        else
+        {
+          if (TestE) Case = 5;
+          else if (TestD) Case = 7;
+          else Case = 6;
+        }
+
+        // Initialize common variables
+        ThisArea = (float) 0.0;
+
+        if (findmoments)
+        {
+          ThisSumX = ThisSumY = (float) 0.0;
+          ThisSumXX = ThisSumYY = ThisSumXY = (float) 0.0;
+        }
+        ThisMinX = ThisMinY = (float) 1000000.0;
+        ThisMaxX = ThisMaxY = (float)-1.0;
+
+        LastPerimeter = ThisPerimeter = (float) 0.0;
+        ThisParent = (float)-1;
+        ThisExternPerimeter = 0.0;
+
+        // Determine necessary action and take it
+        switch (Case)
+        {
+        case 1: //|xxx    |
+          //|    yyy|
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          LastIndex++;
+
+          //afegim la cantonada a LastRegion
+          actualedge.x = ThisEnd;
+          actualedge.y = ThisRow - 1;
+          cvSeqPush(regionDataLastRegion->edges, &actualedge);
+
+          //afegim la cantonada a ThisRegion
+          actualedge.x = ThisStart - 1;
+          actualedge.y = ThisRow - 1;
+          cvSeqPush(regionDataThisRegion->edges, &actualedge);
+
+          break;
+
+
+        case 2: //|xxxxoo |
+          //|    yyy|
+
+          if (TestMatch)	// Same color
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+
+            ThisArea = ThisEnd - ThisStart + 1;
+            LastPerimeter = LastEnd - ThisStart + 1;	// to subtract
+            ThisPerimeter = 2 + 2 * ThisArea - LastPerimeter +
+              PERIMETRE_DIAGONAL * 2;
+
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+              ThisExternPerimeter += PERIMETRE_DIAGONAL * 2;
+            }
+            ComputeData = 1;
+          }
+
+          //afegim la cantonada a ThisRegion
+          if (ThisRegionNum != -1)
+          {
+            // afegim dos vertexs si són diferents, només
+            if (ThisStart - 1 != ThisEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+          }
+          //afegim la cantonada a ThisRegion
+          if (LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            // afegim dos vertexs si són diferents, només
+            if (ThisStart - 1 != ThisEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataLastRegion->edges, &actualedge);
+            }
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          LastIndex++;
+          break;
+
+
+        case 3: //|xxxxxxx|
+          //|  yyyy |
+
+          if (TestMatch)	// Same color
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+
+            ThisArea = ThisEnd - ThisStart + 1;
+            LastPerimeter = ThisArea;	// to subtract
+            ThisPerimeter = 2 + ThisArea + PERIMETRE_DIAGONAL * 2;
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+
+              ThisExternPerimeter += PERIMETRE_DIAGONAL * 2;
+            }
+          }
+          else		// Different color => New region
+          {
+            ThisParent = LastRegionNum;
+            ThisRegionNum = ++HighRegionNum;
+            ThisArea = ThisEnd - ThisStart + 1;
+            ThisPerimeter = 2 + 2 * ThisArea;
+            RegionData.push_back(new CBlob());
+            regionDataThisRegion = RegionData.back();
+
+            SubsumedRegion = NewSubsume(SubsumedRegion, HighRegionNum);
+            if (CandidatExterior)
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+              inputImage->width, inputImage->height,
+              imatgePerimetreExtern);
+
+          }
+
+          if (ThisRegionNum != -1)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            //afegim la cantonada a la regio
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+          }
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+            //afegim la cantonada a la regio
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          ComputeData = 1;
+          ThisIndex++;
+          break;
+
+
+        case 4:	//|xxxxxxx|
+          //|  yyyyy|
+
+          if (TestMatch)	// Same color
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+            ThisArea = ThisEnd - ThisStart + 1;
+            LastPerimeter = ThisArea;	// to subtract
+            ThisPerimeter = 2 + ThisArea + PERIMETRE_DIAGONAL;
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+
+              ThisExternPerimeter += PERIMETRE_DIAGONAL;
+            }
+          }
+          else		// Different color => New region
+          {
+            ThisParent = LastRegionNum;
+            ThisRegionNum = ++HighRegionNum;
+            ThisArea = ThisEnd - ThisStart + 1;
+            ThisPerimeter = 2 + 2 * ThisArea;
+            RegionData.push_back(new CBlob());
+            regionDataThisRegion = RegionData.back();
+            SubsumedRegion = NewSubsume(SubsumedRegion, HighRegionNum);
+            if (CandidatExterior)
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+              inputImage->width, inputImage->height,
+              imatgePerimetreExtern);
+
+          }
+
+          if (ThisRegionNum != -1)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+          }
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          ComputeData = 1;
+
+#ifdef B_CONNECTIVITAT_8
+          if (TestMatch)
+          {
+            LastIndex++;
+            ThisIndex++;
+          }
+          else
+          {
+            LastIndex++;
+          }
+#else
+          LastIndex++;
+          ThisIndex++;
+#endif					
+          break;
+
+
+        case 5:	//|ooxxxxx|
+          //|yyyyyyy|
+
+          if (!TestMatch && !TestKnown)	// Different color and unknown => new region
+          {
+            ThisParent = LastRegionNum;
+            ThisRegionNum = ++HighRegionNum;
+            ThisArea = ThisEnd - ThisStart + 1;
+            ThisPerimeter = 2 + 2 * ThisArea;
+            RegionData.push_back(new CBlob());
+            regionDataThisRegion = RegionData.back();
+            SubsumedRegion = NewSubsume(SubsumedRegion, HighRegionNum);
+            if (CandidatExterior)
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+              inputImage->width, inputImage->height,
+              imatgePerimetreExtern);
+
+          }
+          else if (TestMatch && !TestKnown)	// Same color and unknown
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+            ThisArea = ThisEnd - ThisStart + 1;
+            LastPerimeter = LastEnd - LastStart + 1;	// to subtract
+            ThisPerimeter = 2 + 2 * ThisArea - LastPerimeter
+              + PERIMETRE_DIAGONAL * (LastStart != ThisStart);
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+
+
+              ThisExternPerimeter += PERIMETRE_DIAGONAL * (LastStart != ThisStart);
+            }
+            ComputeData = 1;
+          }
+          else if (TestMatch && TestKnown)	// Same color and known
+          {
+            LastPerimeter = LastEnd - LastStart + 1;	// to subtract
+            //ThisPerimeter = - LastPerimeter;
+            ThisPerimeter = -2 * LastPerimeter
+              + PERIMETRE_DIAGONAL * (LastStart != ThisStart);
+
+            if (ThisRegionNum > LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataThisRegion, regionDataLastRegion,
+                findmoments, ThisRegionNum, LastRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == ThisRegionNum) ThisRegion[iOld] = LastRegionNum;
+                if (LastRegion[iOld] == ThisRegionNum) LastRegion[iOld] = LastRegionNum;
+              }
+              ThisRegionNum = LastRegionNum;
+            }
+            else if (ThisRegionNum < LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataLastRegion, regionDataThisRegion,
+                findmoments, LastRegionNum, ThisRegionNum);
+
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == LastRegionNum) ThisRegion[iOld] = ThisRegionNum;
+                if (LastRegion[iOld] == LastRegionNum) LastRegion[iOld] = ThisRegionNum;
+              }
+              LastRegionNum = ThisRegionNum;
+            }
+          }
+
+
+          if (ThisRegionNum != -1)
+          {
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+
+            if (ThisStart - 1 != LastEnd)
+            {
+              //afegim la cantonada a la regio
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+          }
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+
+#ifdef B_CONNECTIVITAT_8
+          if (TestMatch)
+          {
+            LastIndex++;
+            ThisIndex++;
+          }
+          else
+          {
+            LastIndex++;
+          }
+#else
+          LastIndex++;
+          ThisIndex++;
+#endif	
+          break;
+
+
+        case 6:	//|ooxxx  |
+          //|yyyyyyy|
+
+          if (TestMatch && !TestKnown)
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+            ThisArea = ThisEnd - ThisStart + 1;
+            LastPerimeter = LastEnd - LastStart + 1;	// to subtract
+            ThisPerimeter = 2 + 2 * ThisArea - LastPerimeter
+              + PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+
+
+              ThisExternPerimeter += PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+            }
+            ComputeData = 1;
+          }
+          else if (TestMatch && TestKnown)
+          {
+            LastPerimeter = LastEnd - LastStart + 1;	// to subtract
+            //ThisPerimeter = - LastPerimeter;
+            ThisPerimeter = -2 * LastPerimeter
+              + PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+
+            if (ThisRegionNum > LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataThisRegion, regionDataLastRegion,
+                findmoments, ThisRegionNum, LastRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == ThisRegionNum) ThisRegion[iOld] = LastRegionNum;
+                if (LastRegion[iOld] == ThisRegionNum) LastRegion[iOld] = LastRegionNum;
+              }
+              ThisRegionNum = LastRegionNum;
+            }
+            else if (ThisRegionNum < LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataLastRegion, regionDataThisRegion,
+                findmoments, LastRegionNum, ThisRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == LastRegionNum) ThisRegion[iOld] = ThisRegionNum;
+                if (LastRegion[iOld] == LastRegionNum) LastRegion[iOld] = ThisRegionNum;
+              }
+              LastRegionNum = ThisRegionNum;
+            }
+          }
+
+
+          if (ThisRegionNum != -1)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            if (ThisStart - 1 != LastEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+          }
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            //afegim la cantonada a la regio
+            if (ThisStart - 1 != LastEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          LastIndex++;
+          break;
+
+
+        case 7:	//|ooxxxxx|
+          //|yyyy   |
+
+          if (!TestMatch && !TestKnown)	// Different color and unknown => new region
+          {
+            ThisParent = LastRegionNum;
+            ThisRegionNum = ++HighRegionNum;
+            ThisArea = ThisEnd - ThisStart + 1;
+            ThisPerimeter = 2 + 2 * ThisArea;
+            RegionData.push_back(new CBlob());
+            regionDataThisRegion = RegionData.back();
+            SubsumedRegion = NewSubsume(SubsumedRegion, HighRegionNum);
+            if (CandidatExterior)
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+              inputImage->width, inputImage->height,
+              imatgePerimetreExtern);
+
+          }
+          else if (TestMatch && !TestKnown)
+          {
+            ThisRegionNum = LastRegionNum;
+            regionDataThisRegion = regionDataLastRegion;
+            ThisArea = ThisEnd - ThisStart + 1;
+            ThisPerimeter = 2 + ThisArea;
+            LastPerimeter = ThisEnd - LastStart + 1;
+            ThisPerimeter = 2 + 2 * ThisArea - LastPerimeter
+              + PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+            if (CandidatExterior)
+            {
+              ThisExternPerimeter = GetExternPerimeter(ThisStart, ThisEnd, ThisRow,
+                inputImage->width, inputImage->height,
+                imatgePerimetreExtern);
+
+              ThisExternPerimeter += PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+            }
+            ComputeData = 1;
+          }
+          else if (TestMatch && TestKnown)
+          {
+            LastPerimeter = ThisEnd - LastStart + 1;	// to subtract
+            //ThisPerimeter = - LastPerimeter;
+            ThisPerimeter = -2 * LastPerimeter
+              + PERIMETRE_DIAGONAL + PERIMETRE_DIAGONAL * (ThisStart != LastStart);
+
+            if (ThisRegionNum > LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataThisRegion, regionDataLastRegion,
+                findmoments, ThisRegionNum, LastRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == ThisRegionNum) ThisRegion[iOld] = LastRegionNum;
+                if (LastRegion[iOld] == ThisRegionNum) LastRegion[iOld] = LastRegionNum;
+              }
+              ThisRegionNum = LastRegionNum;
+            }
+            else if (ThisRegionNum < LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataLastRegion, regionDataThisRegion,
+                findmoments, LastRegionNum, ThisRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == LastRegionNum) ThisRegion[iOld] = ThisRegionNum;
+                if (LastRegion[iOld] == LastRegionNum) LastRegion[iOld] = ThisRegionNum;
+              }
+              LastRegionNum = ThisRegionNum;
+            }
+          }
+
+          if (ThisRegionNum != -1)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            if (ThisStart - 1 != LastEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+          }
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisEnd;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+            if (ThisStart - 1 != LastEnd)
+            {
+              actualedge.x = ThisStart - 1;
+              actualedge.y = ThisRow - 1;
+              cvSeqPush(regionDataThisRegion->edges, &actualedge);
+            }
+          }
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          ThisIndex++;
+          break;
+
+        case 8:	//|    xxx|
+          //|yyyy   |
+
+#ifdef B_CONNECTIVITAT_8					
+          // fusionem blobs
+          if (TestMatch)
+          {
+            if (ThisRegionNum > LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataThisRegion, regionDataLastRegion,
+                findmoments, ThisRegionNum, LastRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == ThisRegionNum) ThisRegion[iOld] = LastRegionNum;
+                if (LastRegion[iOld] == ThisRegionNum) LastRegion[iOld] = LastRegionNum;
+              }
+              ThisRegionNum = LastRegionNum;
+            }
+            else if (ThisRegionNum < LastRegionNum)
+            {
+              Subsume(RegionData, HighRegionNum, SubsumedRegion, regionDataLastRegion, regionDataThisRegion,
+                findmoments, LastRegionNum, ThisRegionNum);
+              for (int iOld = 0; iOld < MaxIndexCount; iOld++)
+              {
+                if (ThisRegion[iOld] == LastRegionNum) ThisRegion[iOld] = ThisRegionNum;
+                if (LastRegion[iOld] == LastRegionNum) LastRegion[iOld] = ThisRegionNum;
+              }
+              LastRegionNum = ThisRegionNum;
+            }
+
+            regionDataThisRegion->perimeter = regionDataThisRegion->perimeter + PERIMETRE_DIAGONAL * 2;
+          }
+#endif
+
+          if (ThisRegionNum != -1)
+          {
+            //afegim la cantonada a la regio
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataThisRegion->edges, &actualedge);
+          }
+#ifdef B_CONNECTIVITAT_8					
+          // si hem creat un nou blob, afegim tb a l'anterior
+          if (!TestMatch && LastRegionNum != -1 && LastRegionNum != ThisRegionNum)
+          {
+#endif					
+            //afegim la cantonada a la regio
+            actualedge.x = ThisStart - 1;
+            actualedge.y = ThisRow - 1;
+            cvSeqPush(regionDataLastRegion->edges, &actualedge);
+#ifdef B_CONNECTIVITAT_8
+          }
+#endif
+
+          ThisRegion[ThisIndex] = ThisRegionNum;
+          LastRegion[LastIndex] = LastRegionNum;
+          ThisIndex++;
+#ifdef B_CONNECTIVITAT_8					
+          LastIndex--;
+#endif
+          break;
+
+        default:
+          ErrorFlag = -1;
+        }	// end switch case
+
+        // calculate the blob moments and mean gray level of the current blob (ThisRegionNum)
+        if (ComputeData > 0)
+        {
+          // compute blob moments if necessary
+          if (findmoments)
+          {
+            float ImageRow = (float)(ThisRow - 1);
+
+            for (int k = ThisStart; k <= ThisEnd; k++)
+            {
+              ThisSumX += (float)(k - 1);
+              ThisSumXX += (float)(k - 1) * (k - 1);
+            }
+
+            ThisSumXY = ThisSumX * ImageRow;
+            ThisSumY = ThisArea * ImageRow;
+            ThisSumYY = ThisSumY * ImageRow;
+
+          }
+
+          // compute the mean gray level and its std deviation 
+          if (ThisRow <= Rows)
+          {
+            pImageAux = pImage + ThisStart;
+            if (maskImage != NULL) pMaskAux = pMask + ThisStart;
+            for (int k = ThisStart; k <= ThisEnd; k++)
+            {
+              if ((k > 0) && (k <= Cols))
+              {
+                if (maskImage != NULL)
+                {
+                  // només es té en compte el valor del píxel de la
+                  // imatge que queda dins de la màscara
+                  // (de pas, comptem el nombre de píxels de la màscara)
+                  if (((unsigned char)*pMaskAux) != PIXEL_EXTERIOR)
+                  {
+                    imagevalue = (unsigned char)(*pImageAux);
+                    regionDataThisRegion->mean += imagevalue;
+                    regionDataThisRegion->stddev += imagevalue*imagevalue;
+                  }
+                  else
+                  {
+                    nombre_pixels_mascara++;
+                  }
+                }
+                else
+                {
+                  imagevalue = (unsigned char)(*pImageAux);
+                  regionDataThisRegion->mean += imagevalue;
+                  regionDataThisRegion->stddev += imagevalue*imagevalue;
+
+                }
+              }
+              pImageAux++;
+              if (maskImage != NULL) pMaskAux++;
+            }
+          }
+
+          // compute the min and max values of X and Y
+          if (ThisStart - 1 < (int)ThisMinX) ThisMinX = (float)(ThisStart - 1);
+          if (ThisMinX < (float) 0.0) ThisMinX = (float) 0.0;
+          if (ThisEnd >(int) ThisMaxX) ThisMaxX = (float)ThisEnd;
+
+          if (ThisRow - 1 < ThisMinY) ThisMinY = ThisRow - 1;
+          if (ThisMinY < (float) 0.0) ThisMinY = (float) 0.0;
+          if (ThisRow > ThisMaxY) ThisMaxY = ThisRow;
+        }
+
+        // put the current results into RegionData
+        if (ThisRegionNum >= 0)
+        {
+          if (ThisParent >= 0) { regionDataThisRegion->parent = (int)ThisParent; }
+          regionDataThisRegion->etiqueta = ThisRegionNum;
+          regionDataThisRegion->area += ThisArea;
+          regionDataThisRegion->perimeter += ThisPerimeter;
+          regionDataThisRegion->externPerimeter += ThisExternPerimeter;
+
+          if (ComputeData > 0)
+          {
+            if (findmoments)
+            {
+              regionDataThisRegion->sumx += ThisSumX;
+              regionDataThisRegion->sumy += ThisSumY;
+              regionDataThisRegion->sumxx += ThisSumXX;
+              regionDataThisRegion->sumyy += ThisSumYY;
+              regionDataThisRegion->sumxy += ThisSumXY;
+            }
+            regionDataThisRegion->perimeter -= LastPerimeter;
+            regionDataThisRegion->minx = MIN(regionDataThisRegion->minx, ThisMinX);
+            regionDataThisRegion->maxx = MAX(regionDataThisRegion->maxx, ThisMaxX);
+            regionDataThisRegion->miny = MIN(regionDataThisRegion->miny, ThisMinY);
+            regionDataThisRegion->maxy = MAX(regionDataThisRegion->maxy, ThisMaxY);
+          }
+          // blobs externs
+          if (CandidatExterior)
+          {
+            regionDataThisRegion->exterior = true;
+          }
+
+        }
+      }	// end Main loop
+
+      if (ErrorFlag != 0) {
+          delete[] Transition;
+          delete[] ThisRegion;
+          delete[] LastRegion;
+          return false;
+      }
+      // ens situem al primer pixel de la seguent fila
+      pImage = inputImage->imageData - 1 + startCol + (ThisRow + startRow) * inputImage->widthStep;
+
+      if (maskImage != NULL)
+        pMask = maskImage->imageData - 1 + ThisRow * maskImage->widthStep;
+    }	// end Loop over all rows
+
+    // eliminem l'àrea del marc
+    // i també els píxels de la màscara
+    // ATENCIO: PERFER: el fet de restar el nombre_pixels_mascara del
+    // blob 0 només serà cert si la màscara té contacte amb el marc.
+    // Si no, s'haurà de trobar quin és el blob que conté més píxels del
+    // compte.
+    RegionData[0]->area -= (Rows + 1 + Cols + 1) * 2 + nombre_pixels_mascara;
+
+    // eliminem el perímetre de més:
+    // - sense marc: 2m+2n (perímetre extern)
+    // - amb marc:   2(m+2)+2(n+2) = 2m+2n + 8
+    // (segurament no és del tot acurat)
+    // (i amb les màscares encara menys...)
+    RegionData[0]->perimeter -= 8.0;
+
+    // Condense the list
+    blob_vector::iterator itNew, itOld, iti;
+    CBlob *blobActual;
+
+    itNew = RegionData.begin();
+    itOld = RegionData.begin();
+    int iNew = 0;
+    for (int iOld = 0; iOld <= HighRegionNum; iOld++, itOld++)
+    {
+      if (SubsumedRegion[iOld] < 1)	// This number not subsumed
+      {
+        // Move data from old region number to new region number
+        //*RegionData[iNew] = *RegionData[iOld];
+        **itNew = **itOld;
+
+        // Update and parent pointer if necessary
+        iti = RegionData.begin();
+        for (int i = 0; i <= HighRegionNum; i++)
+        {
+          //if(RegionData[i]->parent == iOld) { RegionData[i]->parent = iNew; }
+          if ((*iti)->parent == iOld) { (*iti)->parent = iNew; }
+
+          ++iti;
+        }
+        iNew++;
+        ++itNew;
+      }
+    }
+
+
+    HighRegionNum = iNew - 1;				// Update where the data ends
+    RegionData[HighRegionNum]->parent = -1;	// and set end of array flag
+
+
+    if (findmoments)
+    {
+      iti = RegionData.begin();
+      // Normalize summation fields into moments 
+      for (ThisRegionNum = 0; ThisRegionNum <= HighRegionNum; ThisRegionNum++, iti++)
+      {
+        blobActual = *iti;
+
+        // Get averages
+        blobActual->sumx /= blobActual->area;
+        blobActual->sumy /= blobActual->area;
+        blobActual->sumxx /= blobActual->area;
+        blobActual->sumyy /= blobActual->area;
+        blobActual->sumxy /= blobActual->area;
+
+        // Create moments
+        blobActual->sumxx -= blobActual->sumx * blobActual->sumx;
+        blobActual->sumyy -= blobActual->sumy * blobActual->sumy;
+        blobActual->sumxy -= blobActual->sumx * blobActual->sumy;
+        if (blobActual->sumxy > -1.0E-14 && blobActual->sumxy < 1.0E-14)
+        {
+          blobActual->sumxy = (float) 0.0; // Eliminate roundoff error
+        }
+
+      }
+    }
+
+    //Get the real mean and std deviation
+    iti = RegionData.begin();
+    for (ThisRegionNum = 0; ThisRegionNum <= HighRegionNum; ThisRegionNum++, iti++)
+    {
+      blobActual = *iti;
+      if (blobActual->area > 1)
+      {
+        blobActual->stddev =
+          sqrt(
+          (
+          blobActual->stddev * blobActual->area -
+          blobActual->mean * blobActual->mean
+          ) /
+          (blobActual->area*(blobActual->area - 1))
+          );
+      }
+      else
+        blobActual->stddev = 0;
+
+      if (blobActual->area > 0)
+        blobActual->mean /= blobActual->area;
+      else
+        blobActual->mean = 0;
+
+    }
+    // eliminem els blobs subsumats
+    blob_vector::iterator itBlobs = RegionData.begin() + HighRegionNum + 1;
+    while (itBlobs != RegionData.end())
+    {
+      delete *itBlobs;
+      //RegionData.erase( itBlobs );
+      ++itBlobs;
+    }
+    RegionData.erase(RegionData.begin() + HighRegionNum + 1, RegionData.end());
+
+    //free(RegionData);
+    free(SubsumedRegion);
+    delete[] Transition;
+    delete[] ThisRegion;
+    delete[] LastRegion;
+
+    if (imatgePerimetreExtern) cvReleaseImage(&imatgePerimetreExtern);
+
+    return true;
+  }
+
+
+  int *NewSubsume(int *subsumed, int index_subsume)
+  {
+    if (index_subsume == 0)
+    {
+      subsumed = (int*)malloc(sizeof(int));
+    }
+    else
+    {
+      subsumed = (int*)realloc(subsumed, (index_subsume + 1)*sizeof(int));
+    }
+    subsumed[index_subsume] = 0;
+    return subsumed;
+  }
+
+  /**
+  Fusiona dos blobs i afegeix el blob les característiques del blob RegionData[HiNum]
+  al blob RegionData[LoNum]. Al final allibera el blob de RegionData[HiNum]
+  */
+  void Subsume(blob_vector &RegionData,
+    int HighRegionNum,
+    int* SubsumedRegion,
+    CBlob* blobHi,
+    CBlob* blobLo,
+    bool findmoments,
+    int HiNum,
+    int LoNum)
+  {
+    // cout << "\nSubsuming " << HiNum << " into " << LoNum << endl; // for debugging
+
+    int i;
+
+    blobLo->minx = MIN(blobHi->minx, blobLo->minx);
+    blobLo->miny = MIN(blobHi->miny, blobLo->miny);
+    blobLo->maxx = MAX(blobHi->maxx, blobLo->maxx);
+    blobLo->maxy = MAX(blobHi->maxy, blobLo->maxy);
+    blobLo->area += blobHi->area;
+    blobLo->perimeter += blobHi->perimeter;
+    blobLo->externPerimeter += blobHi->externPerimeter;
+    blobLo->exterior = blobLo->exterior || blobHi->exterior;
+    blobLo->mean += blobHi->mean;
+    blobLo->stddev += blobHi->stddev;
+
+    if (findmoments)
+    {
+      blobLo->sumx += blobHi->sumx;
+      blobLo->sumy += blobHi->sumy;
+      blobLo->sumxx += blobHi->sumxx;
+      blobLo->sumyy += blobHi->sumyy;
+      blobLo->sumxy += blobHi->sumxy;
+    }
+    // Make sure no region still has subsumed region as parent
+    blob_vector::iterator it = (RegionData.begin() + HiNum + 1);
+
+    for (i = HiNum + 1; i <= HighRegionNum; i++, it++)
+    {
+      if ((*it)->parent == (float)HiNum) { (*it)->parent = LoNum; }
+    }
+
+    // Mark dead region number for future compression
+    SubsumedRegion[HiNum] = 1;
+    // marquem el blob com a lliure
+    blobHi->etiqueta = -1;
+
+    // Atenció!!!! abans d'eliminar els edges 
+    // s'han de traspassar del blob HiNum al blob LoNum
+    blobHi->CopyEdges(*blobLo);
+    blobHi->ClearEdges();
+  }
+
+  /**
+  - FUNCIÓ: GetExternPerimeter
+  - FUNCIONALITAT: Retorna el perimetre extern d'una run lenght
+  - PARÀMETRES:
+  - start: columna d'inici del run
+  - end: columna final del run
+  - row: fila del run
+  - maskImage: màscara pels pixels externs
+  - RESULTAT:
+  - quantitat de perimetre extern d'un run, suposant que és un blob
+  d'una única fila d'alçada
+  - RESTRICCIONS:
+  - AUTOR:
+  - DATA DE CREACIÓ: 2006/02/27
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  double GetExternPerimeter(int start, int end, int row, int width, int height, IplImage *imatgePerimetreExtern)
+  {
+    double perimeter = 0.0f;
+    char *pPerimetre;
+
+
+    // comprovem les dimensions de la imatge
+    perimeter += (start <= 0) + (end >= width - 1);
+    if (row <= 1) perimeter += start - end;
+    if (row >= height - 1) perimeter += start - end;
+
+
+    // comprovem els pixels que toquen a la màscara (si s'escau)
+    if (imatgePerimetreExtern != NULL)
+    {
+      if (row <= 0 || row >= height) return perimeter;
+
+      if (start < 0) start = 1;
+      if (end >= width) end = width - 2;
+
+      pPerimetre = imatgePerimetreExtern->imageData + (row - 1) * imatgePerimetreExtern->widthStep + start;
+      for (int x = start - 1; x <= end; x++)
+      {
+        perimeter += *pPerimetre;
+        pPerimetre++;
+      }
+    }
+
+    return perimeter;
+  }
+
+}

--- a/package_bgs/jmo/BlobExtraction.h
+++ b/package_bgs/jmo/BlobExtraction.h
@@ -1,0 +1,76 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+//***********************************************************//
+//* Blob analysis package  8 August 2003                    *//
+//* Version 1.0                                             *//
+//* Input: IplImage* binary image                           *//
+//* Output: attributes of each connected region             *//
+//* Author: Dave Grossman                                   *//
+//* Email: dgrossman@cdr.stanford.edu                       *//
+//* Acknowledgement: the algorithm has been around > 20 yrs *//
+//***********************************************************//
+
+
+#if !defined(_CLASSE_BLOBEXTRACTION_INCLUDED)
+#define _CLASSE_BLOBEXTRACTION_INCLUDED
+
+namespace Blob
+{
+
+  //! Extreu els blobs d'una imatge
+  bool BlobAnalysis(IplImage* inputImage, uchar threshold, IplImage* maskImage,
+    bool borderColor, bool findmoments, blob_vector &RegionData);
+
+
+  // FUNCIONS AUXILIARS
+
+  //! Fusiona dos blobs
+  void Subsume(blob_vector &RegionData, int, int*, CBlob*, CBlob*, bool, int, int);
+  //! Reallocata el vector auxiliar de blobs subsumats
+  int *NewSubsume(int *SubSumedRegion, int elems_inbuffer);
+  //! Retorna el perimetre extern d'una run lenght
+  double GetExternPerimeter(int start, int end, int row, int width, int height, IplImage *maskImage);
+}
+
+#endif //_CLASSE_BLOBEXTRACTION_INCLUDED
+

--- a/package_bgs/jmo/BlobLibraryConfiguration.h
+++ b/package_bgs/jmo/BlobLibraryConfiguration.h
@@ -1,0 +1,62 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************
+BlobLibraryConfiguration.h
+
+FUNCIONALITAT: Configuració del comportament global de la llibreria
+AUTOR: Inspecta S.L.
+MODIFICACIONS (Modificació, Autor, Data):
+
+FUNCTIONALITY: Global configuration of the library
+AUTHOR: Inspecta S.L.
+MODIFICATIONS (Modification, Author, Date):
+
+**************************************************************************/
+
+//! Indica si es volen fer servir les MatrixCV o no
+//! Use/Not use the MatrixCV class
+//#define MATRIXCV_ACTIU
+
+// Uses/not use the blob object factory
+//#define BLOB_OBJECT_FACTORY
+

--- a/package_bgs/jmo/BlobResult.cpp
+++ b/package_bgs/jmo/BlobResult.cpp
@@ -1,0 +1,847 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************
+BlobResult.cpp
+
+FUNCIONALITAT: Implementació de la classe CBlobResult
+AUTOR: Inspecta S.L.
+MODIFICACIONS (Modificació, Autor, Data):
+
+**************************************************************************/
+
+#include <limits.h>
+#include <stdio.h>
+#include <functional>
+#include <algorithm>
+#include "BlobResult.h"
+#include "BlobExtraction.h"
+
+/**************************************************************************
+Constructors / Destructors
+**************************************************************************/
+
+namespace Blob
+{
+
+  /**
+  - FUNCIÓ: CBlobResult
+  - FUNCIONALITAT: Constructor estandard.
+  - PARÀMETRES:
+  - RESULTAT:
+  - Crea un CBlobResult sense cap blob
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobResult
+  - FUNCTIONALITY: Standard constructor
+  - PARAMETERS:
+  - RESULT:
+  - creates an empty set of blobs
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult::CBlobResult()
+  {
+    m_blobs = blob_vector();
+  }
+
+  /**
+  - FUNCIÓ: CBlobResult
+  - FUNCIONALITAT: Constructor a partir d'una imatge. Inicialitza la seqüència de blobs
+  amb els blobs resultants de l'anàlisi de blobs de la imatge.
+  - PARÀMETRES:
+  - source: imatge d'on s'extreuran els blobs
+  - mask: màscara a aplicar. Només es calcularan els blobs on la màscara sigui
+  diferent de 0. Els blobs que toquin a un pixel 0 de la màscara seran
+  considerats exteriors.
+  - threshold: llindar que s'aplicarà a la imatge source abans de calcular els blobs
+  - findmoments: indica si s'han de calcular els moments de cada blob
+  - RESULTAT:
+  - objecte CBlobResult amb els blobs de la imatge source
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlob
+  - FUNCTIONALITY: Constructor from an image. Fills an object with all the blobs in
+  the image
+  - PARAMETERS:
+  - source: image to extract the blobs from
+  - mask: optional mask to apply. The blobs will be extracted where the mask is
+  not 0. All the neighbouring blobs where the mask is 0 will be extern blobs
+  - threshold: threshold level to apply to the image before computing blobs
+  - findmoments: true to calculate the blob moments (slower)
+  - RESULT:
+  - object with all the blobs in the image. It throws an EXCEPCIO_CALCUL_BLOBS
+  if some error appears in the BlobAnalysis function
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult::CBlobResult(IplImage *source, IplImage *mask, int threshold, bool findmoments)
+  {
+    bool success;
+
+    try
+    {
+      // cridem la funció amb el marc a true=1=blanc (així no unirà els blobs externs)
+      success = BlobAnalysis(source, (uchar)threshold, mask, true, findmoments, m_blobs);
+    }
+    catch (...)
+    {
+      success = false;
+    }
+
+    if (!success) throw EXCEPCIO_CALCUL_BLOBS;
+  }
+
+  /**
+  - FUNCIÓ: CBlobResult
+  - FUNCIONALITAT: Constructor de còpia. Inicialitza la seqüència de blobs
+  amb els blobs del paràmetre.
+  - PARÀMETRES:
+  - source: objecte que es copiarà
+  - RESULTAT:
+  - objecte CBlobResult amb els blobs de l'objecte source
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobResult
+  - FUNCTIONALITY: Copy constructor
+  - PARAMETERS:
+  - source: object to copy
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult::CBlobResult(const CBlobResult &source)
+  {
+    m_blobs = blob_vector(source.GetNumBlobs());
+
+    // creem el nou a partir del passat com a paràmetre
+    m_blobs = blob_vector(source.GetNumBlobs());
+    // copiem els blobs de l'origen a l'actual
+    blob_vector::const_iterator pBlobsSrc = source.m_blobs.begin();
+    blob_vector::iterator pBlobsDst = m_blobs.begin();
+
+    while (pBlobsSrc != source.m_blobs.end())
+    {
+      // no podem cridar a l'operador = ja que blob_vector és un 
+      // vector de CBlob*. Per tant, creem un blob nou a partir del
+      // blob original
+      *pBlobsDst = new CBlob(**pBlobsSrc);
+      ++pBlobsSrc;
+      ++pBlobsDst;
+    }
+  }
+
+
+
+  /**
+  - FUNCIÓ: ~CBlobResult
+  - FUNCIONALITAT: Destructor estandard.
+  - PARÀMETRES:
+  - RESULTAT:
+  - Allibera la memòria reservada de cadascun dels blobs de la classe
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: ~CBlobResult
+  - FUNCTIONALITY: Destructor
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult::~CBlobResult()
+  {
+    ClearBlobs();
+  }
+
+  /**************************************************************************
+  Operadors / Operators
+  **************************************************************************/
+
+
+  /**
+  - FUNCIÓ: operador =
+  - FUNCIONALITAT: Assigna un objecte source a l'actual
+  - PARÀMETRES:
+  - source: objecte a assignar
+  - RESULTAT:
+  - Substitueix els blobs actuals per els de l'objecte source
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: Assigment operator
+  - FUNCTIONALITY:
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult& CBlobResult::operator=(const CBlobResult& source)
+  {
+    // si ja són el mateix, no cal fer res
+    if (this != &source)
+    {
+      // alliberem el conjunt de blobs antic
+      for (int i = 0; i < GetNumBlobs(); i++)
+      {
+        delete m_blobs[i];
+      }
+      m_blobs.clear();
+      // creem el nou a partir del passat com a paràmetre
+      m_blobs = blob_vector(source.GetNumBlobs());
+      // copiem els blobs de l'origen a l'actual
+      blob_vector::const_iterator pBlobsSrc = source.m_blobs.begin();
+      blob_vector::iterator pBlobsDst = m_blobs.begin();
+
+      while (pBlobsSrc != source.m_blobs.end())
+      {
+        // no podem cridar a l'operador = ja que blob_vector és un 
+        // vector de CBlob*. Per tant, creem un blob nou a partir del
+        // blob original
+        *pBlobsDst = new CBlob(**pBlobsSrc);
+        ++pBlobsSrc;
+        ++pBlobsDst;
+      }
+    }
+    return *this;
+  }
+
+
+  /**
+  - FUNCIÓ: operador +
+  - FUNCIONALITAT: Concatena els blobs de dos CBlobResult
+  - PARÀMETRES:
+  - source: d'on s'agafaran els blobs afegits a l'actual
+  - RESULTAT:
+  - retorna un nou CBlobResult amb els dos CBlobResult concatenats
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - NOTA: per la implementació, els blobs del paràmetre es posen en ordre invers
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: + operator
+  - FUNCTIONALITY: Joins the blobs in source with the current ones
+  - PARAMETERS:
+  - source: object to copy the blobs
+  - RESULT:
+  - object with the actual blobs and the source blobs
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlobResult CBlobResult::operator+(const CBlobResult& source)
+  {
+    //creem el resultat a partir dels blobs actuals
+    CBlobResult resultat(*this);
+
+    // reservem memòria per als nous blobs
+    resultat.m_blobs.resize(resultat.GetNumBlobs() + source.GetNumBlobs());
+
+    // declarem els iterador per recòrrer els blobs d'origen i desti
+    blob_vector::const_iterator pBlobsSrc = source.m_blobs.begin();
+    blob_vector::iterator pBlobsDst = resultat.m_blobs.end();
+
+    // insertem els blobs de l'origen a l'actual
+    while (pBlobsSrc != source.m_blobs.end())
+    {
+      --pBlobsDst;
+      *pBlobsDst = new CBlob(**pBlobsSrc);
+      ++pBlobsSrc;
+    }
+
+    return resultat;
+  }
+
+  /**************************************************************************
+  Operacions / Operations
+  **************************************************************************/
+
+  /**
+  - FUNCIÓ: AddBlob
+  - FUNCIONALITAT: Afegeix un blob al conjunt
+  - PARÀMETRES:
+  - blob: blob a afegir
+  - RESULTAT:
+  - modifica el conjunt de blobs actual
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 2006/03/01
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  void CBlobResult::AddBlob(CBlob *blob)
+  {
+    if (blob != NULL)
+      m_blobs.push_back(new CBlob(blob));
+  }
+
+
+  /**
+  - FUNCIÓ: GetSTLResult
+  - FUNCIONALITAT: Calcula el resultat especificat sobre tots els blobs de la classe
+  - PARÀMETRES:
+  - evaluador: Qualsevol objecte derivat de COperadorBlob
+  - RESULTAT:
+  - Retorna un array de double's STL amb el resultat per cada blob
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: GetResult
+  - FUNCTIONALITY: Computes the function evaluador on all the blobs of the class
+  and returns a vector with the result
+  - PARAMETERS:
+  - evaluador: function to apply to each blob (any object derived from the
+  COperadorBlob class )
+  - RESULT:
+  - vector with all the results in the same order as the blobs
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double_stl_vector CBlobResult::GetSTLResult(funcio_calculBlob *evaluador) const
+  {
+    if (GetNumBlobs() <= 0)
+    {
+      return double_stl_vector();
+    }
+
+    // definim el resultat
+    double_stl_vector result = double_stl_vector(GetNumBlobs());
+    // i iteradors sobre els blobs i el resultat
+    double_stl_vector::iterator itResult = result.begin();
+    blob_vector::const_iterator itBlobs = m_blobs.begin();
+
+    // avaluem la funció en tots els blobs
+    while (itBlobs != m_blobs.end())
+    {
+      *itResult = (*evaluador)(**itBlobs);
+      ++itBlobs;
+      ++itResult;
+    }
+    return result;
+  }
+
+  /**
+  - FUNCIÓ: GetNumber
+  - FUNCIONALITAT: Calcula el resultat especificat sobre un únic blob de la classe
+  - PARÀMETRES:
+  - evaluador: Qualsevol objecte derivat de COperadorBlob
+  - indexblob: número de blob del que volem calcular el resultat.
+  - RESULTAT:
+  - Retorna un double amb el resultat
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: GetNumber
+  - FUNCTIONALITY: Computes the function evaluador on a blob of the class
+  - PARAMETERS:
+  - indexBlob: index of the blob to compute the function
+  - evaluador: function to apply to each blob (any object derived from the
+  COperadorBlob class )
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobResult::GetNumber(int indexBlob, funcio_calculBlob *evaluador) const
+  {
+    if (indexBlob < 0 || indexBlob >= GetNumBlobs())
+      RaiseError(EXCEPTION_BLOB_OUT_OF_BOUNDS);
+    return (*evaluador)(*m_blobs[indexBlob]);
+  }
+
+  /////////////////////////// FILTRAT DE BLOBS ////////////////////////////////////
+
+  /**
+  - FUNCIÓ: Filter
+  - FUNCIONALITAT: Filtra els blobs de la classe i deixa el resultat amb només
+  els blobs que han passat el filtre.
+  El filtrat es basa en especificar condicions sobre un resultat dels blobs
+  i seleccionar (o excloure) aquells blobs que no compleixen una determinada
+  condicio
+  - PARÀMETRES:
+  - dst: variable per deixar els blobs filtrats
+  - filterAction:	acció de filtrat. Incloure els blobs trobats (B_INCLUDE),
+  o excloure els blobs trobats (B_EXCLUDE)
+  - evaluador: Funció per evaluar els blobs (qualsevol objecte derivat de COperadorBlob
+  - Condition: tipus de condició que ha de superar la mesura (FilterType)
+  sobre cada blob per a ser considerat.
+  B_EQUAL,B_NOT_EQUAL,B_GREATER,B_LESS,B_GREATER_OR_EQUAL,
+  B_LESS_OR_EQUAL,B_INSIDE,B_OUTSIDE
+  - LowLimit:  valor numèric per a la comparació (Condition) de la mesura (FilterType)
+  - HighLimit: valor numèric per a la comparació (Condition) de la mesura (FilterType)
+  (només té sentit per a aquelles condicions que tenen dos valors
+  (B_INSIDE, per exemple).
+  - RESULTAT:
+  - Deixa els blobs resultants del filtrat a destination
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: Filter
+  - FUNCTIONALITY: Get some blobs from the class based on conditions on measures
+  of the blobs.
+  - PARAMETERS:
+  - dst: where to store the selected blobs
+  - filterAction:	B_INCLUDE: include the blobs which pass the filter in the result
+  B_EXCLUDE: exclude the blobs which pass the filter in the result
+  - evaluador: Object to evaluate the blob
+  - Condition: How to decide if  the result returned by evaluador on each blob
+  is included or not. It can be:
+  B_EQUAL,B_NOT_EQUAL,B_GREATER,B_LESS,B_GREATER_OR_EQUAL,
+  B_LESS_OR_EQUAL,B_INSIDE,B_OUTSIDE
+  - LowLimit:  numerical value to evaluate the Condition on evaluador(blob)
+  - HighLimit: numerical value to evaluate the Condition on evaluador(blob).
+  Only useful for B_INSIDE and B_OUTSIDE
+  - RESULT:
+  - It returns on dst the blobs that accomplish (B_INCLUDE) or discards (B_EXCLUDE)
+  the Condition on the result returned by evaluador on each blob
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlobResult::Filter(CBlobResult &dst,
+    int filterAction,
+    funcio_calculBlob *evaluador,
+    int condition,
+    double lowLimit, double highLimit /*=0*/)
+
+  {
+    int i, numBlobs;
+    bool resultavaluacio;
+    double_stl_vector avaluacioBlobs;
+    double_stl_vector::iterator itavaluacioBlobs;
+
+    if (GetNumBlobs() <= 0) return;
+    if (!evaluador) return;
+    //avaluem els blobs amb la funció pertinent	
+    avaluacioBlobs = GetSTLResult(evaluador);
+    itavaluacioBlobs = avaluacioBlobs.begin();
+    numBlobs = GetNumBlobs();
+    switch (condition)
+    {
+    case B_EQUAL:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs == lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_NOT_EQUAL:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs != lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_GREATER:
+      for (i = 0; i<numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs > lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_LESS:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs < lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_GREATER_OR_EQUAL:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs >= lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_LESS_OR_EQUAL:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = *itavaluacioBlobs <= lowLimit;
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_INSIDE:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = (*itavaluacioBlobs >= lowLimit) && (*itavaluacioBlobs <= highLimit);
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    case B_OUTSIDE:
+      for (i = 0; i < numBlobs; i++, itavaluacioBlobs++)
+      {
+        resultavaluacio = (*itavaluacioBlobs < lowLimit) || (*itavaluacioBlobs > highLimit);
+        if ((resultavaluacio && filterAction == B_INCLUDE) ||
+          (!resultavaluacio && filterAction == B_EXCLUDE))
+        {
+          dst.m_blobs.push_back(new CBlob(GetBlob(i)));
+        }
+      }
+      break;
+    }
+
+
+    // en cas de voler filtrar un CBlobResult i deixar-ho en el mateix CBlobResult
+    // ( operacio inline )
+    if (&dst == this)
+    {
+      // esborrem els primers blobs ( que són els originals )
+      // ja que els tindrem replicats al final si passen el filtre
+      blob_vector::iterator itBlobs = m_blobs.begin();
+      for (int i = 0; i < numBlobs; i++)
+      {
+        delete *itBlobs;
+        ++itBlobs;
+      }
+      m_blobs.erase(m_blobs.begin(), itBlobs);
+    }
+  }
+
+
+  /**
+  - FUNCIÓ: GetBlob
+  - FUNCIONALITAT: Retorna un blob si aquest existeix (index != -1)
+  - PARÀMETRES:
+  - indexblob: index del blob a retornar
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /*
+  - FUNCTION: GetBlob
+  - FUNCTIONALITY: Gets the n-th blob (without ordering the blobs)
+  - PARAMETERS:
+  - indexblob: index in the blob array
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlob CBlobResult::GetBlob(int indexblob) const
+  {
+    if (indexblob < 0 || indexblob >= GetNumBlobs())
+      RaiseError(EXCEPTION_BLOB_OUT_OF_BOUNDS);
+
+    return *m_blobs[indexblob];
+  }
+  CBlob *CBlobResult::GetBlob(int indexblob)
+  {
+    if (indexblob < 0 || indexblob >= GetNumBlobs())
+      RaiseError(EXCEPTION_BLOB_OUT_OF_BOUNDS);
+
+    return m_blobs[indexblob];
+  }
+
+  /**
+  - FUNCIÓ: GetNthBlob
+  - FUNCIONALITAT: Retorna l'enèssim blob segons un determinat criteri
+  - PARÀMETRES:
+  - criteri: criteri per ordenar els blobs (objectes derivats de COperadorBlob)
+  - nBlob: index del blob a retornar
+  - dst: on es retorna el resultat
+  - RESULTAT:
+  - retorna el blob nBlob a dst ordenant els blobs de la classe segons el criteri
+  en ordre DESCENDENT. Per exemple, per obtenir el blob major:
+  GetNthBlob( CBlobGetArea(), 0, blobMajor );
+  GetNthBlob( CBlobGetArea(), 1, blobMajor ); (segon blob més gran)
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /*
+  - FUNCTION: GetNthBlob
+  - FUNCTIONALITY: Gets the n-th blob ordering first the blobs with some criteria
+  - PARAMETERS:
+  - criteri: criteria to order the blob array
+  - nBlob: index of the returned blob in the ordered blob array
+  - dst: where to store the result
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlobResult::GetNthBlob(funcio_calculBlob *criteri, int nBlob, CBlob &dst) const
+  {
+    // verifiquem que no estem accedint fora el vector de blobs
+    if (nBlob < 0 || nBlob >= GetNumBlobs())
+    {
+      //RaiseError( EXCEPTION_BLOB_OUT_OF_BOUNDS );
+      dst = CBlob();
+      return;
+    }
+
+    double_stl_vector avaluacioBlobs, avaluacioBlobsOrdenat;
+    double valorEnessim;
+
+    //avaluem els blobs amb la funció pertinent	
+    avaluacioBlobs = GetSTLResult(criteri);
+
+    avaluacioBlobsOrdenat = double_stl_vector(GetNumBlobs());
+
+    // obtenim els nBlob primers resultats (en ordre descendent)
+    std::partial_sort_copy(avaluacioBlobs.begin(),
+      avaluacioBlobs.end(),
+      avaluacioBlobsOrdenat.begin(),
+      avaluacioBlobsOrdenat.end(),
+      std::greater<double>());
+
+    valorEnessim = avaluacioBlobsOrdenat[nBlob];
+
+    // busquem el primer blob que té el valor n-ssim
+    double_stl_vector::const_iterator itAvaluacio = avaluacioBlobs.begin();
+
+    bool trobatBlob = false;
+    int indexBlob = 0;
+    while (itAvaluacio != avaluacioBlobs.end() && !trobatBlob)
+    {
+      if (*itAvaluacio == valorEnessim)
+      {
+        trobatBlob = true;
+        dst = CBlob(GetBlob(indexBlob));
+      }
+      ++itAvaluacio;
+      indexBlob++;
+    }
+  }
+
+  /**
+  - FUNCIÓ: ClearBlobs
+  - FUNCIONALITAT: Elimina tots els blobs de l'objecte
+  - PARÀMETRES:
+  - RESULTAT:
+  - Allibera tota la memòria dels blobs
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs Navarra
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /*
+  - FUNCTION: ClearBlobs
+  - FUNCTIONALITY: Clears all the blobs from the object and releases all its memory
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlobResult::ClearBlobs()
+  {
+    /*for( int i = 0; i < GetNumBlobs(); i++ )
+    {
+    delete m_blobs[i];
+    }*/
+    blob_vector::iterator itBlobs = m_blobs.begin();
+    while (itBlobs != m_blobs.end())
+    {
+      delete *itBlobs;
+      ++itBlobs;
+    }
+
+    m_blobs.clear();
+  }
+
+  /**
+  - FUNCIÓ: RaiseError
+  - FUNCIONALITAT: Funció per a notificar errors al l'usuari (en debug) i llença
+  les excepcions
+  - PARÀMETRES:
+  - errorCode: codi d'error
+  - RESULTAT:
+  - Ensenya un missatge a l'usuari (en debug) i llença una excepció
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs Navarra
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /*
+  - FUNCTION: RaiseError
+  - FUNCTIONALITY: Error handling function
+  - PARAMETERS:
+  - errorCode: reason of the error
+  - RESULT:
+  - in _DEBUG version, shows a message box with the error. In release is silent.
+  In both cases throws an exception with the error.
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlobResult::RaiseError(const int errorCode) const
+  {
+    throw errorCode;
+  }
+
+
+
+  /**************************************************************************
+  Auxiliars / Auxiliary functions
+  **************************************************************************/
+
+
+  /**
+  - FUNCIÓ: PrintBlobs
+  - FUNCIONALITAT: Escriu els paràmetres (àrea, perímetre, exterior, mitjana)
+  de tots els blobs a un fitxer.
+  - PARÀMETRES:
+  - nom_fitxer: path complet del fitxer amb el resultat
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /*
+  - FUNCTION: PrintBlobs
+  - FUNCTIONALITY: Prints some blob features in an ASCII file
+  - PARAMETERS:
+  - nom_fitxer: full path + filename to generate
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlobResult::PrintBlobs(char *nom_fitxer) const
+  {
+    double_stl_vector area, /*perimetre,*/ exterior, mitjana, compacitat, longitud,
+      externPerimeter, perimetreConvex, perimetre;
+    int i;
+    FILE *fitxer_sortida;
+
+    area = GetSTLResult(CBlobGetArea());
+    perimetre = GetSTLResult(CBlobGetPerimeter());
+    exterior = GetSTLResult(CBlobGetExterior());
+    mitjana = GetSTLResult(CBlobGetMean());
+    compacitat = GetSTLResult(CBlobGetCompactness());
+    longitud = GetSTLResult(CBlobGetLength());
+    externPerimeter = GetSTLResult(CBlobGetExternPerimeter());
+    perimetreConvex = GetSTLResult(CBlobGetHullPerimeter());
+
+    fitxer_sortida = fopen(nom_fitxer, "w");
+
+    for (i = 0; i < GetNumBlobs(); i++)
+    {
+      fprintf(fitxer_sortida, "blob %d ->\t a=%7.0f\t p=%8.2f (%8.2f extern)\t pconvex=%8.2f\t ext=%.0f\t m=%7.2f\t c=%3.2f\t l=%8.2f\n",
+        i, area[i], perimetre[i], externPerimeter[i], perimetreConvex[i], exterior[i], mitjana[i], compacitat[i], longitud[i]);
+    }
+    fclose(fitxer_sortida);
+
+  }
+
+}

--- a/package_bgs/jmo/BlobResult.h
+++ b/package_bgs/jmo/BlobResult.h
@@ -1,0 +1,202 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+ * Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/************************************************************************
+        BlobResult.h
+
+        FUNCIONALITAT: Definició de la classe CBlobResult
+        AUTOR: Inspecta S.L.
+        MODIFICACIONS (Modificació, Autor, Data):
+
+        FUNCTIONALITY: Definition of the CBlobResult class
+        AUTHOR: Inspecta S.L.
+        MODIFICATIONS (Modification, Author, Date):
+
+        **************************************************************************/
+#pragma once
+
+#if !defined(_CLASSE_BLOBRESULT_INCLUDED)
+#define _CLASSE_BLOBRESULT_INCLUDED
+
+#include "BlobLibraryConfiguration.h"
+#include <math.h>
+//#include "cxcore.h"
+#include <vector>
+#include <functional>
+#include "OpenCvLegacyIncludes.h"
+#include "blob.h"
+
+typedef std::vector<double> double_stl_vector;
+
+/**************************************************************************
+  Filtres / Filters
+  **************************************************************************/
+
+//! accions que es poden fer amb els filtres
+//! Actions performed by a filter (include or exclude blobs)
+#define B_INCLUDE				1L
+#define B_EXCLUDE				2L
+
+//! condicions sobre els filtres
+//! Conditions to apply the filters
+#define B_EQUAL					3L
+#define B_NOT_EQUAL				4L
+#define B_GREATER				5L
+#define B_LESS					6L
+#define B_GREATER_OR_EQUAL		7L
+#define B_LESS_OR_EQUAL			8L
+#define B_INSIDE			    9L
+#define B_OUTSIDE			    10L
+
+
+/**************************************************************************
+  Excepcions / Exceptions
+  **************************************************************************/
+
+//! Excepcions llençades per les funcions:
+#define EXCEPTION_BLOB_OUT_OF_BOUNDS	1000
+#define EXCEPCIO_CALCUL_BLOBS			1001
+
+namespace Blob
+{
+
+  //! definició de que es un vector de blobs
+  typedef std::vector<CBlob*>	blob_vector;
+
+  /**
+    Classe que conté un conjunt de blobs i permet extreure'n propietats
+    o filtrar-los segons determinats criteris.
+    Class to calculate the blobs of an image and calculate some properties
+    on them. Also, the class provides functions to filter the blobs using
+    some criteria.
+    */
+  class CBlobResult
+  {
+  public:
+
+    //! constructor estandard, crea un conjunt buit de blobs
+    //! Standard constructor, it creates an empty set of blobs
+    CBlobResult();
+    //! constructor a partir d'una imatge
+    //! Image constructor, it creates an object with the blobs of the image
+    CBlobResult(IplImage *source, IplImage *mask, int threshold, bool findmoments);
+    //! constructor de còpia
+    //! Copy constructor
+    CBlobResult(const CBlobResult &source);
+    //! Destructor
+    virtual ~CBlobResult();
+
+    //! operador = per a fer assignacions entre CBlobResult
+    //! Assigment operator
+    CBlobResult& operator=(const CBlobResult& source);
+    //! operador + per concatenar dos CBlobResult
+    //! Addition operator to concatenate two sets of blobs
+    CBlobResult operator+(const CBlobResult& source);
+
+    //! Afegeix un blob al conjunt
+    //! Adds a blob to the set of blobs
+    void AddBlob(CBlob *blob);
+
+#ifdef MATRIXCV_ACTIU
+    //! Calcula un valor sobre tots els blobs de la classe retornant una MatrixCV
+    //! Computes some property on all the blobs of the class
+    double_vector GetResult( funcio_calculBlob *evaluador ) const;
+#endif
+    //! Calcula un valor sobre tots els blobs de la classe retornant un std::vector<double>
+    //! Computes some property on all the blobs of the class
+    double_stl_vector GetSTLResult(funcio_calculBlob *evaluador) const;
+
+    //! Calcula un valor sobre un blob de la classe
+    //! Computes some property on one blob of the class
+    double GetNumber(int indexblob, funcio_calculBlob *evaluador) const;
+
+    //! Retorna aquells blobs que compleixen les condicions del filtre en el destination 
+    //! Filters the blobs of the class using some property
+    void Filter(CBlobResult &dst,
+      int filterAction, funcio_calculBlob *evaluador,
+      int condition, double lowLimit, double highLimit = 0);
+
+    //! Retorna l'enèssim blob segons un determinat criteri
+    //! Sorts the blobs of the class acording to some criteria and returns the n-th blob
+    void GetNthBlob(funcio_calculBlob *criteri, int nBlob, CBlob &dst) const;
+
+    //! Retorna el blob enèssim
+    //! Gets the n-th blob of the class ( without sorting )
+    CBlob GetBlob(int indexblob) const;
+    CBlob *GetBlob(int indexblob);
+
+    //! Elimina tots els blobs de l'objecte
+    //! Clears all the blobs of the class
+    void ClearBlobs();
+
+    //! Escriu els blobs a un fitxer
+    //! Prints some features of all the blobs in a file
+    void PrintBlobs(char *nom_fitxer) const;
+
+
+    //Metodes GET/SET
+
+    //! Retorna el total de blobs
+    //! Gets the total number of blobs
+    int GetNumBlobs() const
+    {
+      return(m_blobs.size());
+    }
+
+
+  private:
+
+    //! Funció per gestionar els errors
+    //! Function to manage the errors
+    void RaiseError(const int errorCode) const;
+
+  protected:
+
+    //! Vector amb els blobs
+    //! Vector with all the blobs
+    blob_vector		m_blobs;
+  };
+
+}
+
+#endif // !defined(_CLASSE_BLOBRESULT_INCLUDED)
+

--- a/package_bgs/jmo/CMultiLayerBGS.cpp
+++ b/package_bgs/jmo/CMultiLayerBGS.cpp
@@ -1,0 +1,2150 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// BackgroundSubtraction.cpp: implementation of the CMultiLayerBGS class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "CMultiLayerBGS.h"
+
+#include <ctime>						// clock
+#include <cstdlib>						// C standard library
+#include <cstdio>						// C I/O (for sscanf)
+#include <cstring>						// string manipulation
+#include <fstream>						// file I/O
+#include <cmath>						// math includes
+#include <iostream>                                             // I/O streams
+#include "OpenCvLegacyIncludes.h"
+
+using namespace Blob;
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+CMultiLayerBGS::CMultiLayerBGS() {
+  m_nMaxLBPModeNum = MAX_LBP_MODE_NUM;
+
+  m_fModeUpdatingLearnRate = MODE_UPDATING_LEARN_RATE;
+  m_f1_ModeUpdatingLearnRate = 1.0f - m_fModeUpdatingLearnRate;
+
+  m_fWeightUpdatingLearnRate = WEIGHT_UPDATING_LEARN_RATE;
+  m_f1_WeightUpdatingLearnRate = 1.0f - m_fWeightUpdatingLearnRate;
+
+  m_fRobustColorOffset = ROBUST_COLOR_OFFSET;
+
+  m_fLowInitialModeWeight = LOW_INITIAL_MODE_WEIGHT;
+
+  m_fPatternColorDistBgThreshold = PATTERN_COLOR_DIST_BACKGROUND_THRESHOLD;
+  m_fPatternColorDistBgUpdatedThreshold = PATTERN_COLOR_DIST_BACKGROUND_THRESHOLD;
+
+  m_fBackgroundModelPercent = BACKGROUND_MODEL_PERCENT;
+
+  m_nPatternDistSmoothNeigHalfSize = PATTERN_DIST_SMOOTH_NEIG_HALF_SIZE;
+  m_fPatternDistConvGaussianSigma = PATTERN_DIST_CONV_GAUSSIAN_SIGMA;
+
+  m_fRobustShadowRate = ROBUST_SHADOW_RATE;
+  m_fRobustHighlightRate = ROBUST_HIGHLIGHT_RATE;
+
+  m_nCurImgFrameIdx = 0;
+
+  m_pBkMaskImg = NULL;
+
+  m_bUsedColorLBP = false;
+  m_bUsedGradImage = false;
+
+  m_fMinLBPBinaryProb = 0.1f;
+  m_f1_MinLBPBinaryProb = 1.0f - m_fMinLBPBinaryProb;
+
+  m_pOrgImg = m_pFgImg = m_pBgImg = m_pFgMaskImg = m_pBgDistImg = m_pEdgeImg = NULL;
+  m_ppOrgLBPImgs = NULL;
+
+  m_disableLearning = false;
+  m_fSigmaS = 3.0f;
+  m_fSigmaR = 0.1f;
+
+  m_fTextureWeight = 0.5f;
+  m_fColorWeight = 1.0f - m_fTextureWeight;
+
+  m_fWeightUpdatingConstant = 5.0f;
+
+  m_fReliableBackgroundModeWeight = 0.9f;
+
+  //m_fMinBgLayerWeight = m_fLowInitialModeWeight/50.0f;
+  m_fMinBgLayerWeight = 0.0001f;
+  //m_fMinBgLayerWeight = 0.88f;
+
+  m_fMinNoisedAngle = 3.0f / 180.0f * PI;
+  m_fMinNoisedAngleSine = sinf(m_fMinNoisedAngle);
+
+  m_fFrameDuration = 1.0f / 25.0f; /* 25 frames per second */
+
+  m_fModeUpdatingLearnRatePerSecond = 0.2f;
+  m_fWeightUpdatingLearnRatePerSecond = 0.2f;
+
+  m_pROI = NULL;
+}
+
+CMultiLayerBGS::~CMultiLayerBGS() {
+  int img_length = m_cvImgSize.height * m_cvImgSize.width;
+  PixelLBPStruct* PLBP = m_pPixelLBPs;
+  for (int yx = 0; yx < img_length; yx++) {
+    delete (*PLBP).cur_intensity;
+    delete (*PLBP).cur_pattern;
+    delete (*PLBP).lbp_idxes;
+    for (int a = 0; a < m_nMaxLBPModeNum; a++) {
+      delete (*PLBP).LBPs[a].bg_intensity;
+      delete (*PLBP).LBPs[a].max_intensity;
+      delete (*PLBP).LBPs[a].min_intensity;
+      delete (*PLBP).LBPs[a].bg_pattern;
+    }
+    delete (*PLBP).LBPs;
+    PLBP++;
+  }
+  delete m_pPixelLBPs;
+
+  /* release memories */
+  if (m_pFgImg != NULL)
+    cvReleaseImage(&m_pFgImg);
+  if (m_pBgImg != NULL)
+    cvReleaseImage(&m_pBgImg);
+  if (m_pBgDistImg != NULL)
+    cvReleaseImage(&m_pBgDistImg);
+  if (m_ppOrgLBPImgs != NULL) {
+    int a;
+    for (a = 0; a < m_nLBPImgNum; a++)
+      cvReleaseImage(&m_ppOrgLBPImgs[a]);
+    delete[] m_ppOrgLBPImgs;
+  }
+  if (m_pEdgeImg)
+    cvReleaseImage(&m_pEdgeImg);
+}
+
+void CMultiLayerBGS::ResetAllParameters() {
+  m_f1_ModeUpdatingLearnRate = 1.0f - m_fModeUpdatingLearnRate;
+  m_f1_WeightUpdatingLearnRate = 1.0f - m_fWeightUpdatingLearnRate;
+  m_f1_MinLBPBinaryProb = 1.0f - m_fMinLBPBinaryProb;
+
+  m_fColorWeight = 1.0f - m_fTextureWeight;
+
+  m_fMinNoisedAngleSine = sinf(m_fMinNoisedAngle);
+
+  //m_fMinBgLayerWeight = m_fLowInitialModeWeight/50.0f;
+  m_fMinBgLayerWeight = 0.0001f;
+
+  m_cLBP.m_fRobustWhiteNoise = m_fRobustColorOffset;
+}
+
+void CMultiLayerBGS::MergeImages(int num, ...) {
+  if (num < 1 || num > 9) {
+    printf("Error: the number %d of merging images.\n", num);
+    exit(0);
+  }
+
+  int nCols = 0, nRows = 0;
+  switch (num) {
+  case 1: nCols = nRows = 1;
+    break;
+  case 2: nCols = 1;
+    nRows = 2;
+    break;
+  case 3:
+  case 4: nCols = 2;
+    nRows = 2;
+    break;
+  case 5:
+  case 6: nCols = 3;
+    nRows = 2;
+    break;
+  case 7:
+  case 8:
+  case 9: nCols = 3;
+    nRows = 3;
+    break;
+  }
+
+  int a, b;
+
+  IplImage** ppIplImg = new IplImage*[num + 1];
+
+  va_list arg_ptr;
+  va_start(arg_ptr, num);
+  for (a = 0; a < num + 1; a++)
+    ppIplImg[a] = va_arg(arg_ptr, IplImage*);
+  va_end(arg_ptr);
+
+  CvRect imgROIRect;
+  CvSize imgSize = cvGetSize(ppIplImg[0]);
+  if (ppIplImg[num] == NULL) { // for the output video
+    ppIplImg[num] = cvCreateImage(cvSize(imgSize.width*nCols, imgSize.height * nRows), IPL_DEPTH_8U, ppIplImg[0]->nChannels);
+  }
+
+  int img_idx = 0;
+  for (a = 0; a < nRows; a++)
+  for (b = 0; b < nCols; b++) {
+    if (img_idx >= num)
+      break;
+
+    imgROIRect = cvRect(b * imgSize.width, a * imgSize.height, imgSize.width, imgSize.height);
+
+    cvSetImageROI(ppIplImg[num], imgROIRect);
+    cvCopy(ppIplImg[img_idx++], ppIplImg[num]);
+    cvResetImageROI(ppIplImg[num]);
+  }
+
+  delete[] ppIplImg;
+}
+
+void CMultiLayerBGS::Update_MAX_MIN_Intensity(unsigned char *cur_intensity, float *max_intensity, float *min_intensity) {
+  int a;
+  float curI;
+  for (a = 0; a < m_nChannel; a++) {
+    curI = (float)cur_intensity[a];
+
+    min_intensity[a] = MIN(curI, min_intensity[a]);
+    max_intensity[a] = MAX(curI, max_intensity[a]);
+  }
+}
+
+void CMultiLayerBGS::UpdateBgPixelColor(unsigned char *cur_intensity, float* bg_intensity) {
+  int a;
+  for (a = 0; a < m_nChannel; a++)
+    bg_intensity[a] = m_f1_ModeUpdatingLearnRate * bg_intensity[a] + m_fModeUpdatingLearnRate * (float)cur_intensity[a];
+}
+
+void CMultiLayerBGS::UpdateBgPixelPattern(float *cur_pattern, float *bg_pattern) {
+  int a;
+  for (a = 0; a < m_nLBPLength; a++)
+    bg_pattern[a] = m_f1_ModeUpdatingLearnRate * bg_pattern[a] + m_fModeUpdatingLearnRate * cur_pattern[a];
+}
+
+/* sort everything inbetween `low' <-> `high' */
+void CMultiLayerBGS::QuickSort(float *pData, unsigned short *pIdxes, long low, long high, bool bAscent) {
+  long i = low;
+  long j = high;
+  float y = 0;
+  int idx = 0;
+
+  /* compare value */
+  float z = pData[(low + high) / 2];
+
+  /* partition */
+  do {
+    if (bAscent) {
+      /* find member above ... */
+      while (pData[i] < z) i++;
+
+      /* find element below ... */
+      while (pData[j] > z) j--;
+    }
+    else {
+      /* find member below ... */
+      while (pData[i] > z) i++;
+
+      /* find element above ... */
+      while (pData[j] < z) j--;
+    }
+
+    if (i <= j) {
+      /* swap two elements */
+      y = pData[i];
+      pData[i] = pData[j];
+      pData[j] = y;
+
+      idx = pIdxes[i];
+      pIdxes[i] = pIdxes[j];
+      pIdxes[j] = idx;
+
+      i++;
+      j--;
+    }
+  } while (i <= j);
+
+  /* recurse */
+  if (low < j)
+    QuickSort(pData, pIdxes, low, j, bAscent);
+
+  if (i < high)
+    QuickSort(pData, pIdxes, i, high, bAscent);
+}
+
+float CMultiLayerBGS::DistLBP(LBPStruct *LBP1, LBPStruct *LBP2) {
+  int a;
+
+  float pattern_dist = 0;
+  for (a = 0; a < m_nLBPLength; a++) {
+    pattern_dist = fabsf(LBP1->bg_pattern[a] - LBP1->bg_pattern[a]);
+  }
+  pattern_dist /= (float)m_nLBPLength;
+
+  float color_dist = 0;
+  for (a = 0; a < m_nChannel; a++) {
+    color_dist += fabsf((float)LBP1->bg_intensity[a] - (float)LBP2->bg_intensity[a]);
+  }
+  color_dist /= 3.0f * 125.0f;
+
+  //return MAX(pattern_dist, color_dist);
+  return color_dist;
+}
+
+void CMultiLayerBGS::SetNewImage(IplImage *new_img, CvRect *roi) {
+  m_pOrgImg = new_img;
+  m_pROI = roi;
+  if (roi && (roi->width <= 0 || roi->height <= 0))
+    return;
+
+  if (roi) {
+    cvSetImageROI(m_pOrgImg, *roi);
+    for (int a = 0; a < m_nLBPImgNum; a++)
+      cvSetImageROI(m_ppOrgLBPImgs[a], *roi);
+  }
+
+  switch (m_nLBPImgNum) {
+  case 1:
+    cvCvtColor(m_pOrgImg, m_ppOrgLBPImgs[0], CV_BGR2GRAY);
+    break;
+  case 2:
+    cvCvtColor(m_pOrgImg, m_ppOrgLBPImgs[0], CV_BGR2GRAY);
+    ComputeGradientImage(m_ppOrgLBPImgs[0], m_ppOrgLBPImgs[1], false);
+    break;
+  case 3:
+    cvSplit(m_pOrgImg, m_ppOrgLBPImgs[0], m_ppOrgLBPImgs[1], m_ppOrgLBPImgs[2], NULL);
+    break;
+  case 4:
+    cvSplit(m_pOrgImg, m_ppOrgLBPImgs[0], m_ppOrgLBPImgs[1], m_ppOrgLBPImgs[2], NULL);
+    ComputeGradientImage(m_ppOrgLBPImgs[0], m_ppOrgLBPImgs[3], false);
+    break;
+  }
+
+  if (roi) {
+    cvResetImageROI(m_pOrgImg);
+    for (int a = 0; a < m_nLBPImgNum; a++)
+      cvResetImageROI(m_ppOrgLBPImgs[a]);
+  }
+  m_cLBP.SetNewImages(m_ppOrgLBPImgs);
+
+  m_nCurImgFrameIdx++;
+}
+
+void CMultiLayerBGS::SetBkMaskImage(IplImage *mask_img) {
+  if (m_pBkMaskImg == NULL) {
+    m_pBkMaskImg = cvCreateImage(cvGetSize(mask_img), mask_img->depth, mask_img->nChannels);
+  }
+  cvCopy(mask_img, m_pBkMaskImg);
+}
+
+void CMultiLayerBGS::BackgroundSubtractionProcess() {
+  CvRect *roi = m_pROI;
+
+  if (roi && (roi->width <= 0 || roi->height <= 0))
+    return;
+  LBPStruct* LBPs;
+  unsigned int bg_num;
+  float* cur_pattern;
+  unsigned char* cur_intensity;
+  int a, b;
+  unsigned int lbp_num;
+  unsigned short* lbp_idxes;
+  unsigned short cur_lbp_idx;
+  bool bBackgroundUpdating;
+
+  PixelLBPStruct *PLBP = m_pPixelLBPs;
+
+  bool bFirstFrame = (PLBP[0].num == 0);
+  float best_match_bg_dist, bg_pattern_dist, bg_color_dist, bg_pattern_color_dist;
+
+  // compute the local binary pattern
+  if (m_fTextureWeight > 0)
+    m_cLBP.ComputeLBP(PLBP, roi);
+
+  LBPStruct* curLBP;
+
+  int data_length;
+
+  if (roi)
+    data_length = roi->width * roi->height;
+  else
+    data_length = m_cvImgSize.width * m_cvImgSize.height;
+
+  int best_match_idx;
+
+  COpencvDataConversion<uchar, uchar> ODC1;
+  if (roi) {
+    cvSetImageROI(m_pBkMaskImg, *roi);
+    cvSetImageROI(m_pOrgImg, *roi);
+  }
+  uchar *_mask = ODC1.GetImageData(m_pBkMaskImg);
+  uchar *_org_intensity = ODC1.GetImageData(m_pOrgImg);
+
+  if (roi) {
+    cvResetImageROI(m_pBkMaskImg);
+    cvResetImageROI(m_pOrgImg);
+  }
+
+  COpencvDataConversion<float, float> ODC2;
+  float *_bg_dist = new float[data_length];
+
+  uchar *mask = _mask;
+  uchar *org_intensity = _org_intensity;
+  float *bg_dist = _bg_dist;
+
+  bool removed_modes[10];
+
+  // scanning the point via first x-axis and then y-axis
+  int x, y;
+
+  for (y = 0; y < (roi ? roi->height : m_cvImgSize.height); y++) {
+    if (roi)
+      PLBP = m_pPixelLBPs + (roi->y + y) * m_cvImgSize.width + roi->x;
+    else
+      PLBP = m_pPixelLBPs + y * m_cvImgSize.width;
+
+    for (x = 0; x < (roi ? roi->width : m_cvImgSize.width); x++) {
+      // check whether the current pixel is the pixel to be modeled
+      if (*mask++ == 0) {
+        PLBP++;
+        *bg_dist++ = 0.0f; //m_fPatternColorDistBgThreshold*1.01f;
+        org_intensity += m_nChannel;
+        continue;
+      }
+
+      // removing the background layers
+      if (!m_disableLearning) {
+        RemoveBackgroundLayers(PLBP);
+      }
+
+      // check whether the current image is the first image
+      bFirstFrame = ((*PLBP).num == 0);
+
+      // get lbp information
+      lbp_num = (*PLBP).num;
+      LBPs = (*PLBP).LBPs;
+      lbp_idxes = (*PLBP).lbp_idxes;
+
+      (*PLBP).cur_bg_layer_no = 0;
+
+      // set the current pixel's intensity
+      cur_intensity = (*PLBP).cur_intensity;
+      for (a = 0; a < m_nChannel; a++)
+        cur_intensity[a] = *org_intensity++;
+
+      // get the current lbp pattern
+      cur_pattern = (*PLBP).cur_pattern;
+
+      // first check whether the pixel is background or foreground and then update the background pattern model
+      if (lbp_num == 0) { // empty pattern list
+        curLBP = (&(LBPs[0]));
+        for (a = 0; a < m_nLBPLength; a++) {
+          curLBP->bg_pattern[a] = (float)cur_pattern[a];
+        }
+
+        curLBP->bg_layer_num = 0;
+        curLBP->weight = m_fLowInitialModeWeight;
+        curLBP->max_weight = m_fLowInitialModeWeight;
+
+        curLBP->first_time = m_nCurImgFrameIdx;
+        curLBP->last_time = m_nCurImgFrameIdx;
+        curLBP->freq = 1;
+
+        (*PLBP).matched_mode_first_time = (float)m_nCurImgFrameIdx;
+
+        for (a = 0; a < m_nChannel; a++) {
+          curLBP->bg_intensity[a] = (float)cur_intensity[a];
+          curLBP->min_intensity[a] = (float)cur_intensity[a];
+          curLBP->max_intensity[a] = (float)cur_intensity[a];
+        }
+
+        lbp_idxes[0] = 0;
+
+        lbp_num++;
+        (*PLBP).num = 1;
+        (*PLBP).bg_num = 1;
+
+        PLBP++;
+        *bg_dist++ = 0.0f;
+        continue;
+      }
+      else { // not empty pattern list
+        /*
+        // remove the background layers
+        // end of removing the background layer
+        */
+
+        best_match_idx = -1;
+        best_match_bg_dist = 999.0f;
+
+        // find the best match
+        for (a = 0; a < (int)lbp_num; a++) {
+          // get the current index for lbp pattern
+          cur_lbp_idx = lbp_idxes[a];
+
+          // get the current LBP pointer
+          curLBP = &(LBPs[cur_lbp_idx]);
+
+          // compute the background probability based on lbp pattern
+          bg_pattern_dist = 0.0f;
+          if (m_fTextureWeight > 0)
+            bg_pattern_dist = CalPatternBgDist(cur_pattern, curLBP->bg_pattern);
+
+          // compute the color invariant probability based on RGB color
+          bg_color_dist = 0.0f;
+          if (m_fColorWeight > 0)
+            bg_color_dist = CalColorBgDist(cur_intensity, curLBP->bg_intensity, curLBP->max_intensity, curLBP->min_intensity);
+
+          // compute the joint background probability
+          //bg_pattern_color_dist = sqrtf(bg_color_dist*bg_pattern_dist);
+
+          //UpdatePatternColorDistWeights(cur_pattern, curLBP->bg_pattern);
+
+          bg_pattern_color_dist = m_fColorWeight * bg_color_dist + m_fTextureWeight*bg_pattern_dist;
+          //bg_pattern_color_dist = MAX(bg_color_dist, bg_pattern_dist);
+
+          //bg_pattern_color_dist = 1.0f - (1.0f-bg_color_dist)*(1.0-bg_pattern_dist);
+          //bg_pattern_color_dist = bg_pattern_dist;
+
+          //bg_pattern_color_dist = bg_color_dist;
+
+          if (bg_pattern_color_dist < best_match_bg_dist) {
+            best_match_bg_dist = bg_pattern_color_dist;
+            best_match_idx = a;
+          }
+        }
+
+        bg_num = (*PLBP).bg_num;
+
+        // check
+        bBackgroundUpdating = ((best_match_bg_dist < m_fPatternColorDistBgUpdatedThreshold));
+
+        // reset the weight of the mode
+        if (best_match_idx >= (int)bg_num && LBPs[lbp_idxes[best_match_idx]].max_weight < m_fReliableBackgroundModeWeight) // found not in the background models
+          best_match_bg_dist = MAX(best_match_bg_dist, m_fPatternColorDistBgThreshold * 2.5f);
+
+        *bg_dist = best_match_bg_dist;
+      }
+      if (m_disableLearning) {
+        // no creation or update when learning is disabled
+      }
+      else if (!bBackgroundUpdating) { // no match
+
+        for (a = 0; a < (int)lbp_num; a++) { // decrease the weights
+          curLBP = &(LBPs[lbp_idxes[a]]);
+          curLBP->weight *= (1.0f - m_fWeightUpdatingLearnRate / (1.0f + m_fWeightUpdatingConstant * curLBP->max_weight));
+        }
+
+        if ((int)lbp_num < m_nMaxLBPModeNum) { // add a new pattern
+          // find the pattern index for addition
+          int add_lbp_idx = 0;
+          bool bFound;
+          for (a = 0; a < m_nMaxLBPModeNum; a++) {
+            bFound = true;
+            for (b = 0; b < (int)lbp_num; b++)
+              bFound &= (a != lbp_idxes[b]);
+            if (bFound) {
+              add_lbp_idx = a;
+              break;
+            }
+          }
+          curLBP = &(LBPs[add_lbp_idx]);
+
+          curLBP->first_time = m_nCurImgFrameIdx;
+          curLBP->last_time = m_nCurImgFrameIdx;
+          curLBP->freq = 1;
+          curLBP->layer_time = -1;
+
+          (*PLBP).matched_mode_first_time = (float)m_nCurImgFrameIdx;
+
+          for (a = 0; a < m_nLBPLength; a++) {
+            curLBP->bg_pattern[a] = (float)cur_pattern[a];
+          }
+
+          curLBP->bg_layer_num = 0;
+          curLBP->weight = m_fLowInitialModeWeight;
+          curLBP->max_weight = m_fLowInitialModeWeight;
+
+          for (a = 0; a < m_nChannel; a++) {
+            curLBP->bg_intensity[a] = (float)cur_intensity[a];
+            curLBP->min_intensity[a] = (float)cur_intensity[a];
+            curLBP->max_intensity[a] = (float)cur_intensity[a];
+          }
+
+          lbp_idxes[lbp_num] = add_lbp_idx;
+
+          lbp_num++;
+          (*PLBP).num = lbp_num;
+        }
+        else { // replacing the pattern with the minimal weight
+          // find the replaced pattern index
+          /*
+          int rep_pattern_idx = -1;
+          for ( a = m_nLBPLength-1 ; a >= 0 ; a-- ) {
+          if ( LBPs[lbp_idxes[a]].bg_layer_num == 0 )
+          rep_pattern_idx = lbp_idxes[a];
+          }
+          if ( rep_pattern_idx < 0 ) {
+          rep_pattern_idx = lbp_idxes[m_nMaxLBPModeNum-1];
+          for ( a = 0 ; a < m_nLBPLength ; a++ ) {
+          if ( LBPs[lbp_idxes[a]].bg_layer_num > LBPs[rep_pattern_idx].bg_layer_num )
+          LBPs[lbp_idxes[a]].bg_layer_num--;
+          }
+          }
+          */
+          int rep_pattern_idx = lbp_idxes[m_nMaxLBPModeNum - 1];
+
+          curLBP = &(LBPs[rep_pattern_idx]);
+
+          curLBP->first_time = m_nCurImgFrameIdx;
+          curLBP->last_time = m_nCurImgFrameIdx;
+          curLBP->freq = 1;
+          curLBP->layer_time = -1;
+
+          (*PLBP).matched_mode_first_time = (float)m_nCurImgFrameIdx;
+
+          for (a = 0; a < m_nLBPLength; a++) {
+            curLBP->bg_pattern[a] = (float)cur_pattern[a];
+          }
+
+          curLBP->bg_layer_num = 0;
+          curLBP->weight = m_fLowInitialModeWeight;
+          curLBP->max_weight = m_fLowInitialModeWeight;
+
+          for (a = 0; a < m_nChannel; a++) {
+            curLBP->bg_intensity[a] = (float)cur_intensity[a];
+            curLBP->min_intensity[a] = (float)cur_intensity[a];
+            curLBP->max_intensity[a] = (float)cur_intensity[a];
+          }
+        }
+      }
+      else { // find match
+        // updating the background pattern model
+        cur_lbp_idx = lbp_idxes[best_match_idx];
+        curLBP = &(LBPs[cur_lbp_idx]);
+
+        curLBP->first_time = MAX(MIN(curLBP->first_time, m_nCurImgFrameIdx), 0);
+        (*PLBP).matched_mode_first_time = curLBP->first_time;
+
+        curLBP->last_time = m_nCurImgFrameIdx;
+        curLBP->freq++;
+
+        if (m_fColorWeight > 0) {
+          // update the color information
+          UpdateBgPixelColor(cur_intensity, curLBP->bg_intensity);
+          // update the MAX and MIN color intensity
+          Update_MAX_MIN_Intensity(cur_intensity, curLBP->max_intensity, curLBP->min_intensity);
+        }
+
+        // update the texture information
+        if (m_fTextureWeight > 0)
+          UpdateBgPixelPattern(cur_pattern, curLBP->bg_pattern);
+
+
+        // increase the weight of the best matched mode
+        float increasing_weight_factor = m_fWeightUpdatingLearnRate * (1.0f + m_fWeightUpdatingConstant * curLBP->max_weight);
+        curLBP->weight = (1.0f - increasing_weight_factor) * curLBP->weight + increasing_weight_factor; //*expf(-best_match_dist/m_fPatternColorDistBgThreshold);
+
+        // update the maximal weight for the best matched mode
+        curLBP->max_weight = MAX(curLBP->weight, curLBP->max_weight);
+
+        // calculate the number of background layer
+        if (curLBP->bg_layer_num > 0) {
+          bool removed_bg_layers = false;
+          if (curLBP->weight > curLBP->max_weight * 0.2f) {
+            for (a = 0; a < (int)lbp_num; a++) {
+              removed_modes[a] = false;
+              if (LBPs[lbp_idxes[a]].bg_layer_num > curLBP->bg_layer_num &&
+                LBPs[lbp_idxes[a]].weight < LBPs[lbp_idxes[a]].max_weight * 0.9f) { /* remove layers */
+                //LBPs[lbp_idxes[a]].bg_layer_num = 0;
+                removed_modes[a] = true;
+                removed_bg_layers = true;
+              }
+            }
+          }
+
+          if (removed_bg_layers) {
+            RemoveBackgroundLayers(PLBP, removed_modes);
+            lbp_num = (*PLBP).num;
+          }
+        }
+        else if (curLBP->max_weight > m_fReliableBackgroundModeWeight && curLBP->bg_layer_num == 0) {
+          int max_bg_layer_num = LBPs[lbp_idxes[0]].bg_layer_num;
+          for (a = 1; a < (int)lbp_num; a++)
+            max_bg_layer_num = MAX(max_bg_layer_num, LBPs[lbp_idxes[a]].bg_layer_num);
+          curLBP->bg_layer_num = max_bg_layer_num + 1;
+          curLBP->layer_time = m_nCurImgFrameIdx;
+        }
+
+        (*PLBP).cur_bg_layer_no = curLBP->bg_layer_num;
+
+        // decrease the weights of non-best matched modes
+        for (a = 0; a < (int)lbp_num; a++) {
+          if (a != best_match_idx) {
+            curLBP = &(LBPs[lbp_idxes[a]]);
+            curLBP->weight *= (1.0f - m_fWeightUpdatingLearnRate / (1.0f + m_fWeightUpdatingConstant * curLBP->max_weight));
+          }
+        }
+      }
+
+      // sort the list of modes based on the weights of modes
+      if ((int)lbp_num > 1 && !m_disableLearning) {
+        float weights[100], tot_weights = 0;
+        for (a = 0; a < (int)lbp_num; a++) {
+          weights[a] = LBPs[lbp_idxes[a]].weight;
+          tot_weights += weights[a];
+        }
+
+        // sort weights in the descent order
+        QuickSort(weights, lbp_idxes, 0, (int)lbp_num - 1, false);
+
+        // calculate the first potential background modes number, bg_num
+        float threshold_weight = m_fBackgroundModelPercent*tot_weights;
+        tot_weights = 0;
+        for (a = 0; a < (int)lbp_num; a++) {
+          tot_weights += LBPs[lbp_idxes[a]].weight;
+          if (tot_weights > threshold_weight) {
+            bg_num = a + 1;
+            break;
+          }
+        }
+        (*PLBP).bg_num = bg_num;
+      }
+
+      PLBP++;
+      bg_dist++;
+    }
+  }
+
+  if (bFirstFrame) { // check whether it is the first frame for background modeling
+    if (m_pFgMaskImg)
+      cvSetZero(m_pFgMaskImg);
+    cvSetZero(m_pBgDistImg);
+  }
+  else {
+    // set the image data
+    if (roi) {
+      cvSetZero(m_pBgDistImg);
+      cvSetImageROI(m_pBgDistImg, *roi);
+    }
+    ODC2.SetImageData(m_pBgDistImg, _bg_dist);
+
+    // do gaussian smooth
+    if (m_nPatternDistSmoothNeigHalfSize >= 0)
+      cvSmooth(m_pBgDistImg, m_pBgDistImg, CV_GAUSSIAN, (2 * m_nPatternDistSmoothNeigHalfSize + 1), (2 * m_nPatternDistSmoothNeigHalfSize + 1), m_fPatternDistConvGaussianSigma);
+
+    if (roi)
+      cvResetImageROI(m_pBgDistImg);
+#ifdef LINUX_BILATERAL_FILTER
+    // do cross bilateral filter
+    fprintf(stderr, "%f %f\n", m_fSigmaS, m_fSigmaR);
+    if (m_fSigmaS > 0 && m_fSigmaR > 0) {
+      GetFloatEdgeImage(m_ppOrgLBPImgs[0], m_pEdgeImg);
+      //ComputeGradientImage(m_ppOrgLBPImgs[0], m_pEdgeImg, true);
+      m_cCrossBF.SetNewImages(m_pBgDistImg, m_pEdgeImg);
+      m_cCrossBF.FastCrossBF();
+      m_cCrossBF.GetFilteredImage(m_pBgDistImg);
+    }
+#endif
+
+    // get the foreground mask by thresholding
+    if (m_pFgMaskImg)
+      cvThreshold(m_pBgDistImg, m_pFgMaskImg, m_fPatternColorDistBgThreshold, 255, CV_THRESH_BINARY);
+
+    // get the foreground probability image (uchar)
+    if (m_pFgProbImg)
+      GetForegroundProbabilityImage(m_pFgProbImg);
+
+    // do post-processing
+    //Postprocessing();
+  }
+
+  // release memories
+  delete[] _mask;
+  delete[] _bg_dist;
+  delete[] _org_intensity;
+}
+
+void CMultiLayerBGS::GetBackgroundImage(IplImage *bk_img) {
+  IplImage *bg_img = m_pBgImg;
+  uchar *c1;
+  float *c2;
+  int bg_img_idx;
+  int channel;
+  int img_length = m_cvImgSize.height * m_cvImgSize.width;
+  int yx;
+
+  COpencvDataConversion<uchar, uchar> ODC;
+  uchar *org_data = ODC.GetImageData(bg_img);
+  c1 = org_data;
+
+  //c1 = (uchar*)(bg_img->imageData);
+
+  PixelLBPStruct* PLBP = m_pPixelLBPs;
+
+  for (yx = 0; yx < img_length; yx++) {
+    // the newest background image
+    bg_img_idx = (*PLBP).lbp_idxes[0];
+    if ((*PLBP).num == 0) {
+      for (channel = 0; channel < m_nChannel; channel++)
+        *c1++ = 0;
+    }
+    else {
+      c2 = (*PLBP).LBPs[bg_img_idx].bg_intensity;
+      for (channel = 0; channel < m_nChannel; channel++)
+        *c1++ = cvRound(*c2++);
+    }
+    PLBP++;
+  }
+
+  ODC.SetImageData(bg_img, org_data);
+  delete[] org_data;
+
+  cvCopy(m_pBgImg, bk_img);
+}
+
+void CMultiLayerBGS::GetForegroundImage(IplImage *fg_img, CvScalar bg_color) {
+  if (m_pROI && (m_pROI->width <= 0 || m_pROI->height <= 0))
+    return;
+  IplImage* org_img;
+  IplImage* fg_mask_img; // the Mat pointer of the foreground mask matrices at different levels
+
+  org_img = m_pOrgImg;
+  fg_mask_img = m_pFgMaskImg;
+
+  cvSet(fg_img, bg_color);
+  if (m_pROI) {
+    cvSetImageROI(org_img, *m_pROI);
+    cvSetImageROI(fg_img, *m_pROI);
+    cvSetImageROI(fg_mask_img, *m_pROI);
+    cvCopy(org_img, fg_img, fg_mask_img);
+    cvResetImageROI(org_img);
+    cvResetImageROI(fg_img);
+    cvResetImageROI(fg_mask_img);
+  }
+  else
+    cvCopy(org_img, fg_img, fg_mask_img);
+}
+
+void CMultiLayerBGS::GetForegroundMaskImage(IplImage *fg_mask_img) {
+  if (m_pROI && (m_pROI->width <= 0 || m_pROI->height <= 0))
+    return;
+
+  //cvCopy(m_pFgMaskImg, fg_mask_img);
+  if (m_pROI) {
+    cvSetImageROI(m_pFgMaskImg, *m_pROI);
+    cvSetImageROI(fg_mask_img, *m_pROI);
+    cvThreshold(m_pFgMaskImg, fg_mask_img, 0, 255, CV_THRESH_BINARY);
+    cvResetImageROI(m_pFgMaskImg);
+    cvResetImageROI(fg_mask_img);
+  }
+  else
+    cvThreshold(m_pFgMaskImg, fg_mask_img, 0, 255, CV_THRESH_BINARY);
+}
+
+void CMultiLayerBGS::GetForegroundMaskMap(CvMat *fg_mask_mat) {
+  COpencvDataConversion<uchar, uchar> ODC;
+  ODC.ConvertData(m_pFgMaskImg, fg_mask_mat);
+}
+
+void CMultiLayerBGS::GetCurrentBackgroundDistMap(CvMat *bk_dist_map) {
+  cvCopy(m_pBgDistImg, bk_dist_map);
+}
+
+void CMultiLayerBGS::Initialization(IplImage *first_img, int lbp_level_num, float *radiuses, int *neig_pt_nums) {
+  int a;
+
+  m_nLBPLength = 0;
+  m_nLBPLevelNum = lbp_level_num;
+  for (a = 0; a < lbp_level_num; a++) {
+    m_nLBPLength += neig_pt_nums[a];
+    m_pLBPRadiuses[a] = radiuses[a];
+    m_pLBPMeigPointNums[a] = neig_pt_nums[a];
+  }
+
+  m_pFgImg = NULL;
+  m_pFgMaskImg = NULL;
+  m_pBgDistImg = NULL;
+  m_pOrgImg = NULL;
+  m_pBgImg = NULL;
+  m_ppOrgLBPImgs = NULL;
+  m_pFgProbImg = NULL;
+
+  m_cvImgSize = cvGetSize(first_img);
+
+  m_nChannel = first_img->nChannels;
+
+  m_pOrgImg = first_img;
+
+  if (m_bUsedColorLBP && m_bUsedGradImage)
+    m_nLBPImgNum = 4;
+  else if (m_bUsedColorLBP && !m_bUsedGradImage)
+    m_nLBPImgNum = 3;
+  else if (!m_bUsedColorLBP && m_bUsedGradImage)
+    m_nLBPImgNum = 2;
+  else
+    m_nLBPImgNum = 1;
+
+  m_nLBPLength *= m_nLBPImgNum;
+
+  m_ppOrgLBPImgs = new IplImage*[m_nLBPImgNum];
+  for (a = 0; a < m_nLBPImgNum; a++)
+    m_ppOrgLBPImgs[a] = cvCreateImage(m_cvImgSize, IPL_DEPTH_8U, 1);
+
+  m_pBgImg = cvCreateImage(m_cvImgSize, IPL_DEPTH_8U, m_nChannel);
+  m_pFgImg = cvCreateImage(m_cvImgSize, IPL_DEPTH_8U, m_nChannel);
+  m_pEdgeImg = cvCreateImage(m_cvImgSize, IPL_DEPTH_32F, 1);
+  m_pBgDistImg = cvCreateImage(m_cvImgSize, IPL_DEPTH_32F, 1);
+
+  ResetAllParameters();
+
+  int img_length = m_cvImgSize.height * m_cvImgSize.width;
+  m_pPixelLBPs = new PixelLBPStruct[img_length];
+  PixelLBPStruct* PLBP = m_pPixelLBPs;
+  int yx;
+  for (yx = 0; yx < img_length; yx++) {
+    (*PLBP).cur_intensity = new unsigned char[m_nChannel];
+    (*PLBP).cur_pattern = new float[m_nLBPLength];
+    (*PLBP).LBPs = new LBPStruct[m_nMaxLBPModeNum];
+    (*PLBP).lbp_idxes = new unsigned short[m_nMaxLBPModeNum];
+    (*PLBP).lbp_idxes[0] = 0;
+    (*PLBP).num = 0;
+    (*PLBP).cur_bg_layer_no = 0;
+    (*PLBP).matched_mode_first_time = 0;
+    for (a = 0; a < m_nMaxLBPModeNum; a++) {
+      (*PLBP).LBPs[a].bg_intensity = new float[m_nChannel];
+      (*PLBP).LBPs[a].max_intensity = new float[m_nChannel];
+      (*PLBP).LBPs[a].min_intensity = new float[m_nChannel];
+      (*PLBP).LBPs[a].bg_pattern = new float[m_nLBPLength];
+      (*PLBP).LBPs[a].first_time = -1;
+      (*PLBP).LBPs[a].last_time = -1;
+      (*PLBP).LBPs[a].freq = -1;
+      (*PLBP).LBPs[a].layer_time = -1;
+    }
+    PLBP++;
+  }
+
+  m_pBkMaskImg = cvCreateImage(m_cvImgSize, IPL_DEPTH_8U, 1);
+  cvSet(m_pBkMaskImg, cvScalar(1));
+
+  m_cLBP.Initialization(m_ppOrgLBPImgs, m_nLBPImgNum, lbp_level_num, radiuses, neig_pt_nums, m_fRobustColorOffset);
+
+#ifdef LINUX_BILATERAL_FILTER
+  if (m_fSigmaS > 0 && m_fSigmaR > 0)
+    m_cCrossBF.Initialization(m_pBgDistImg, m_pBgDistImg, m_fSigmaS, m_fSigmaR);
+#endif
+}
+
+float CMultiLayerBGS::CalPatternBgDist(float *cur_pattern, float *bg_pattern) {
+  float bg_hamming_dist = 0;
+  int a;
+  for (a = 0; a < m_nLBPLength; a++)
+    bg_hamming_dist += fabsf(cur_pattern[a] - bg_pattern[a]) > m_f1_MinLBPBinaryProb;
+
+  bg_hamming_dist /= (float)m_nLBPLength;
+
+  return bg_hamming_dist;
+}
+
+float CMultiLayerBGS::CalColorBgDist(uchar *cur_intensity, float *bg_intensity, float *max_intensity, float *min_intensity) {
+  float noised_angle, range_dist, bg_color_dist;
+
+  range_dist = CalColorRangeDist(cur_intensity, bg_intensity, max_intensity, min_intensity, m_fRobustShadowRate, m_fRobustHighlightRate);
+
+  if (range_dist == 1.0f)
+    bg_color_dist = range_dist;
+  else {
+    noised_angle = CalVectorsNoisedAngle(bg_intensity, cur_intensity, MAX(m_fRobustColorOffset, 5.0f), m_nChannel);
+    bg_color_dist = (1.0f - expf(-100.0f * noised_angle * noised_angle));
+  }
+
+  //float bg_color_dist = (expf(-100.0f*noised_angle*noised_angle)*(1.0f-range_dist);
+
+  //float bg_color_dist =  0.5f*(1.0f-expf(-noised_angle*noised_angle/0.005f)) + 0.5f*range_dist;
+  //float bg_color_dist =  MAX((float)(noised_angle>0.08f), range_dist);
+
+  return bg_color_dist;
+}
+
+void CMultiLayerBGS::ComputeGradientImage(IplImage *src, IplImage *dst, bool bIsFloat) {
+  if (src->nChannels != 1 || dst->nChannels != 1) {
+    printf("Input images error for computing gradient images!");
+    exit(1);
+  }
+
+  int a;
+
+  IplImage* _dX = cvCreateImage(cvGetSize(dst), IPL_DEPTH_16S, 1);
+  IplImage* _dY = cvCreateImage(cvGetSize(dst), IPL_DEPTH_16S, 1);
+
+  int aperture_size = 3;
+
+  cvSobel(src, _dX, 1, 0, aperture_size);
+  cvSobel(src, _dY, 0, 1, aperture_size);
+
+  COpencvDataConversion<short, short> ODC1;
+  COpencvDataConversion<uchar, uchar> ODC2;
+  COpencvDataConversion<float, float> ODC3;
+
+  short* dX_data = ODC1.GetImageData(_dX);
+  short* dY_data = ODC1.GetImageData(_dY);
+
+  uchar* dst_u_data = NULL;
+  float* dst_f_data = NULL;
+
+  if (bIsFloat)
+    dst_f_data = ODC3.GetImageData(dst);
+  else
+    dst_u_data = ODC2.GetImageData(dst);
+
+  short* dX = dX_data;
+  short* dY = dY_data;
+  uchar *uSrc = dst_u_data;
+  float *fSrc = dst_f_data;
+
+  /*
+  short* dX = (short*)(_dX->imageData);
+  short* dY = (short*)(_dY->imageData);
+  uchar *dSrc = (uchar*)(dst->imageData);
+  */
+
+  int length;
+  if (src->roi)
+    length = dst->width * dst->height;
+  else
+    length = dst->roi->width * dst->roi->height;
+  /*
+  int x, y;
+  uchar *x_u_data;
+  float *x_f_data;
+  */
+
+  if (bIsFloat) {
+    for (a = 0; a < length; a++) {
+      *fSrc = cvSqrt((float)((*dX)*(*dX) + (*dY)*(*dY)) / (32.0f * 255.0f));
+      fSrc++;
+      dX++;
+      dY++;
+    }
+    ODC3.SetImageData(dst, dst_f_data);
+    delete[] dst_f_data;
+  }
+  else {
+    for (a = 0; a < length; a++) {
+      *uSrc = cvRound(cvSqrt((float)((*dX)*(*dX) + (*dY)*(*dY)) / 32.0f));
+      uSrc++;
+      dX++;
+      dY++;
+    }
+    ODC2.SetImageData(dst, dst_u_data);
+    delete[] dst_u_data;
+  }
+
+  delete[] dX_data;
+  delete[] dY_data;
+
+  cvReleaseImage(&_dX);
+  cvReleaseImage(&_dY);
+}
+
+float CMultiLayerBGS::CalVectorsNoisedAngle(float *bg_color, unsigned char *noised_color, float offset, int length) {
+  float org_angle = CalVectorsAngle(bg_color, noised_color, length);
+  float norm_color = 0, elem, noised_angle;
+  int a;
+  for (a = 0; a < length; a++) {
+    elem = bg_color[a];
+    norm_color += elem*elem;
+  }
+  norm_color = sqrtf(norm_color);
+  if (norm_color == 0)
+    noised_angle = PI;
+  else {
+    float sin_angle = offset / norm_color;
+    if (sin_angle < m_fMinNoisedAngleSine)
+      noised_angle = m_fMinNoisedAngle;
+    else
+      //noised_angle = ( sin_angle >= 1 ? PI : asinf(sin_angle));
+      noised_angle = (sin_angle >= 1 ? PI : sin_angle);
+  }
+
+  float angle = org_angle - noised_angle;
+  if (angle < 0)
+    angle = 0;
+  return angle;
+
+  /*
+  float org_angle = CalVectorsAngle(bg_color, noised_color, length);
+  float max_norm_color, bg_norm_color = 0, noised_norm_color = 0, elem, noised_angle;
+  int a;
+  for ( a = 0 ; a <  length ; a++ ) {
+  elem = bg_color[a];
+  bg_norm_color += elem*elem;
+  elem = (float)noised_color[a];
+  noised_norm_color += elem*elem;
+  }
+  max_norm_color = MIN(bg_norm_color, noised_norm_color);
+  max_norm_color = sqrtf(max_norm_color);
+  if ( max_norm_color == 0 )
+  noised_angle = PI;
+  else {
+  float sin_angle = offset/max_norm_color;
+  noised_angle = ( sin_angle >= 1 ? PI : asinf(sin_angle));
+  }
+
+  float angle = org_angle-noised_angle;
+  if ( angle < 0 )
+  angle = 0;
+  return angle;
+  */
+}
+
+float CMultiLayerBGS::CalVectorsAngle(float *c1, unsigned char *c2, int length) {
+  float angle;
+  float dot2, norm1, norm2, elem1, elem2;
+
+  dot2 = norm1 = norm2 = 0;
+
+  int a;
+  for (a = 0; a < length; a++) {
+    elem1 = (float)(c1[a]);
+    elem2 = (float)(c2[a]);
+    dot2 += elem1*elem2;
+    norm1 += elem1*elem1;
+    norm2 += elem2*elem2;
+  }
+
+  //angle = (norm1*norm2==0 ? 0 : acosf(dot2/sqrtf(norm1*norm2)));
+  //angle = (norm1 * norm2 == 0 ? 0 : sqrtf(fmax(1.0f - dot2 * dot2 / (norm1 * norm2), 0.f)));
+  angle = (norm1 * norm2 == 0 ? 0 : sqrtf(std::max(1.0f - dot2 * dot2 / (norm1 * norm2), 0.f)));
+
+  return angle;
+}
+
+float CMultiLayerBGS::CalColorRangeDist(unsigned char *cur_intensity, float *bg_intensity, float *max_intensity, float *min_intensity, float shadow_rate, float highlight_rate) {
+  float dist = 0.0f, minI, maxI, bgI, curI;
+  int channel;
+  //float cdist;
+
+
+  for (channel = 0; channel < m_nChannel; channel++) {
+    bgI = bg_intensity[channel];
+
+    /*
+    minI = MIN(MIN(min_intensity[channel], bgI*shadow_rate), min_intensity[channel]-15.0f);
+    maxI = MAX(MAX(max_intensity[channel], bgI*highlight_rate), max_intensity[channel]+15.0f);
+    */
+
+    minI = MIN(min_intensity[channel], bgI * shadow_rate - 5.0f);
+    maxI = MAX(max_intensity[channel], bgI * highlight_rate + 5.0f);
+
+    /*
+    if ( rand()/((double)RAND_MAX+1) > 0.999 ) {
+    char msg[200];
+    sprintf(msg, "%d\t%d\n", min_intensity[channel]<bgI*shadow_rate-5.0f ? 1 : 0, max_intensity[channel]>bgI*highlight_rate+5.0f ? 1 : 0);
+    ExportLogMessage(msg);
+    }
+    */
+
+    /*
+    minI = max_intensity[channel]*shadow_rate;
+    maxI = MAX(bg_intensity[channel]+m_fRobustColorOffset, MIN(max_intensity[channel]*highlight_rate,min_intensity[channel]/shadow_rate));
+    */
+
+    curI = (float)(cur_intensity[channel]);
+
+    /*
+    //cdist = fabsf(bgI-curI)/512.0f;
+    if ( curI > bgI )
+    cdist = fabsf(bgI-curI)/256.0f;
+    else
+    cdist = fabsf(bgI-curI)/512.0f;
+
+    if ( curI > maxI )
+    //cdist += (curI-maxI)/(2.0f*(255.0f-maxI))*0.5f;
+    cdist += (1.0f-expf(10.0f*(maxI-curI)/MAX(255.0f-maxI,10.0f)))*0.5f;
+    else if ( curI < minI )
+    //cdist += (minI-curI)/(2.0f*minI)*0.5f;
+    cdist += (1.0f-expf(10.0f*(curI-minI)/MAX(minI,10.0f)))*0.5f;
+    //dist += cdist;
+    if ( cdist > dist )
+    dist = cdist;
+    */
+
+    if (curI > maxI || curI < minI) {
+      dist = 1.0f;
+      break;
+    }
+  }
+  //dist = powf(dist, 1.0f/(float)m_nChannel);
+  //dist /= (float)m_nChannel;
+
+  return dist;
+}
+
+void CMultiLayerBGS::GetLayeredBackgroundImage(int layered_no, IplImage *layered_bg_img, CvScalar empty_color) {
+  PixelLBPStruct *PLBP = m_pPixelLBPs;
+  LBPStruct* LBPs;
+  unsigned short* lbp_idxes;
+
+  int a, b, c;
+  int img_length = m_pOrgImg->width * m_pOrgImg->height;
+
+  cvSet(layered_bg_img, empty_color);
+
+  COpencvDataConversion<uchar, uchar> ODC;
+
+  uchar *bg_img_data = ODC.GetImageData(layered_bg_img);
+  uchar *_bg_img_data = bg_img_data;
+  float *cur_bg_intensity;
+  int lbp_num;
+
+  for (a = 0; a < img_length; a++) {
+    // get lbp information
+    LBPs = (*PLBP).LBPs;
+    lbp_idxes = (*PLBP).lbp_idxes;
+    lbp_num = (int)((*PLBP).num);
+    bool found = false;
+    for (b = 0; b < lbp_num; b++) {
+      if (LBPs[lbp_idxes[b]].bg_layer_num == layered_no) {
+        cur_bg_intensity = LBPs[lbp_idxes[b]].bg_intensity;
+        for (c = 0; c < m_pOrgImg->nChannels; c++)
+          *_bg_img_data++ = (uchar)* cur_bg_intensity++;
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      _bg_img_data += m_pOrgImg->nChannels;
+
+    PLBP++;
+  }
+
+  ODC.SetImageData(layered_bg_img, bg_img_data);
+
+  delete[] bg_img_data;
+}
+
+void CMultiLayerBGS::GetBgLayerNoImage(IplImage *bg_layer_no_img, CvScalar *layer_colors, int layer_num) {
+  if (layer_num != 0 && layer_num != m_nMaxLBPModeNum) {
+    printf("Must be set in %d layers in function GetBgLayerNoImage!\n", m_nMaxLBPModeNum);
+    exit(1);
+  }
+
+  CvScalar *bg_layer_colors;
+  int bg_layer_color_num = layer_num;
+  if (bg_layer_color_num == 0)
+    bg_layer_color_num = m_nMaxLBPModeNum;
+  bg_layer_colors = new CvScalar[bg_layer_color_num];
+  if (layer_colors) {
+    for (int l = 0; l < layer_num; l++)
+      bg_layer_colors[l] = layer_colors[l];
+  }
+  else {
+    int rgb[3];
+    rgb[0] = rgb[1] = rgb[2] = 0;
+    int rgb_idx = 0;
+    for (int l = 0; l < bg_layer_color_num; l++) {
+      bg_layer_colors[l] = CV_RGB(rgb[0], rgb[1], rgb[2]);
+      rgb[rgb_idx] += 200;
+      rgb[rgb_idx] %= 255;
+      rgb_idx++;
+      rgb_idx %= 3;
+    }
+  }
+
+  int img_length = m_pOrgImg->width * m_pOrgImg->height;
+  uchar *bg_layer_data = new uchar[img_length * bg_layer_no_img->nChannels];
+  uchar *_bg_layer_data = bg_layer_data;
+
+  PixelLBPStruct *PLBP = m_pPixelLBPs;
+  unsigned int cur_bg_layer_no;
+
+  for (int a = 0; a < img_length; a++) {
+    cur_bg_layer_no = (*PLBP).cur_bg_layer_no;
+    for (int b = 0; b < bg_layer_no_img->nChannels; b++) {
+      *_bg_layer_data++ = (uchar)(bg_layer_colors[cur_bg_layer_no].val[b]);
+    }
+    PLBP++;
+  }
+
+  COpencvDataConversion<uchar, uchar> ODC;
+  ODC.SetImageData(bg_layer_no_img, bg_layer_data);
+
+  delete[] bg_layer_data;
+  delete[] bg_layer_colors;
+}
+
+void CMultiLayerBGS::GetCurrentLayeredBackgroundImage(int layered_no, IplImage *layered_bg_img, IplImage *layered_fg_img, CvScalar layered_bg_bk_color, CvScalar layered_fg_color,
+  int smooth_win, float smooth_sigma, float below_layer_noise, float above_layer_noise, int min_blob_size) {
+  PixelLBPStruct *PLBP = m_pPixelLBPs;
+  LBPStruct* LBPs;
+  unsigned short* lbp_idxes;
+
+  int a;
+  int img_length = m_pOrgImg->width * m_pOrgImg->height;
+
+  float *bg_layer_mask = new float[img_length];
+  float *_bg_layer_mask = bg_layer_mask;
+
+  for (a = 0; a < img_length; a++) {
+    // get lbp information
+    LBPs = (*PLBP).LBPs;
+    lbp_idxes = (*PLBP).lbp_idxes;
+    *_bg_layer_mask++ = (float)(*PLBP).cur_bg_layer_no;
+    PLBP++;
+  }
+
+  COpencvDataConversion<float, float> ODC;
+  IplImage* bg_layer_float_mask_img = cvCreateImage(cvGetSize(m_pOrgImg), IPL_DEPTH_32F, 1);
+  IplImage* bg_layer_low_mask_img = cvCreateImage(cvGetSize(m_pOrgImg), IPL_DEPTH_8U, 1);
+  IplImage* bg_layer_high_mask_img = cvCreateImage(cvGetSize(m_pOrgImg), IPL_DEPTH_8U, 1);
+  IplImage* bg_layer_mask_img = cvCreateImage(cvGetSize(m_pOrgImg), IPL_DEPTH_8U, 1);
+
+  ODC.SetImageData(bg_layer_float_mask_img, bg_layer_mask);
+
+  /* method 1 using smooth */
+  /*
+  cvSmooth(bg_layer_float_mask_img, bg_layer_float_mask_img, CV_GAUSSIAN, smooth_win, smooth_win, smooth_sigma);
+
+  cvThreshold(bg_layer_float_mask_img, bg_layer_low_mask_img, (float)layered_no-below_layer_noise, 1, CV_THRESH_BINARY);
+  cvThreshold(bg_layer_float_mask_img, bg_layer_high_mask_img, (float)layered_no+above_layer_noise, 1, CV_THRESH_BINARY_INV);
+
+  cvAnd(bg_layer_low_mask_img, bg_layer_high_mask_img, bg_layer_mask_img);
+  */
+
+  /* method 2 using dilate, erode, blob removing */
+  cvSmooth(bg_layer_float_mask_img, bg_layer_float_mask_img, CV_GAUSSIAN, smooth_win, smooth_win, smooth_sigma);
+
+  cvThreshold(bg_layer_float_mask_img, bg_layer_low_mask_img, (float)layered_no - below_layer_noise, 1, CV_THRESH_BINARY);
+  cvThreshold(bg_layer_float_mask_img, bg_layer_high_mask_img, (float)layered_no + above_layer_noise, 1, CV_THRESH_BINARY_INV);
+  cvAnd(bg_layer_low_mask_img, bg_layer_high_mask_img, bg_layer_mask_img);
+
+  cvDilate(bg_layer_mask_img, bg_layer_mask_img, 0, 2);
+  cvErode(bg_layer_mask_img, bg_layer_mask_img, 0, 2);
+
+  //cvMorphologyEx(bg_layer_mask_img, bg_layer_mask_img, NULL, 0, CV_MOP_OPEN|CV_MOP_CLOSE, 1);
+
+  // Extract the blobs using a threshold of 100 in the image
+  CBlobResult blobs = CBlobResult(bg_layer_mask_img, NULL, 0, true);
+  // discard the blobs with less area than 100 pixels
+  // ( the criteria to filter can be any class derived from COperadorBlob )
+  blobs.Filter(blobs, B_INCLUDE, CBlobGetArea(), B_GREATER, min_blob_size);
+
+  CBlob filtered_blob;
+  cvSetZero(bg_layer_mask_img);
+  for (a = 0; a < blobs.GetNumBlobs(); a++) {
+    filtered_blob = blobs.GetBlob(a);
+    filtered_blob.FillBlob(bg_layer_mask_img, cvScalar(1));
+  }
+  blobs.GetNthBlob(CBlobGetArea(), 0, filtered_blob);
+  filtered_blob.FillBlob(bg_layer_mask_img, cvScalar(0));
+
+
+  cvSet(layered_bg_img, layered_bg_bk_color);
+  cvCopy(m_pBgImg, layered_bg_img, bg_layer_mask_img);
+
+  if (layered_fg_img) {
+    cvCopy(m_pOrgImg, layered_fg_img);
+    cvSet(layered_fg_img, layered_fg_color, bg_layer_mask_img);
+  }
+
+  cvReleaseImage(&bg_layer_float_mask_img);
+  cvReleaseImage(&bg_layer_low_mask_img);
+  cvReleaseImage(&bg_layer_high_mask_img);
+  cvReleaseImage(&bg_layer_mask_img);
+  delete[] bg_layer_mask;
+}
+
+void CMultiLayerBGS::GetColoredBgMultiLayeredImage(IplImage *bg_multi_layer_img, CvScalar *layer_colors) {
+  cvCopy(m_pOrgImg, bg_multi_layer_img);
+
+  COpencvDataConversion<uchar, uchar> ODC;
+
+  uchar *bg_ml_imgD = ODC.GetImageData(bg_multi_layer_img);
+  uchar *fg_maskD = ODC.GetImageData(m_pFgMaskImg);
+
+  uchar *_bg_ml_imgD = bg_ml_imgD;
+  uchar *_fg_maskD = fg_maskD;
+
+  PixelLBPStruct *PLBP = m_pPixelLBPs;
+  LBPStruct* LBPs;
+  unsigned short* lbp_idxes;
+  unsigned int lbp_num;
+  int bg_layer_num;
+
+  int a, c;
+  int img_length = m_pOrgImg->width * m_pOrgImg->height;
+  int channels = m_pOrgImg->nChannels;
+  bool bLayeredBg;
+
+  for (a = 0; a < img_length; a++) {
+    // get lbp information
+    lbp_num = (*PLBP).num;
+    LBPs = (*PLBP).LBPs;
+    lbp_idxes = (*PLBP).lbp_idxes;
+    bLayeredBg = false;
+
+    if ((*_fg_maskD == 0)) {
+      bg_layer_num = LBPs[lbp_idxes[0]].bg_layer_num;
+      int first_layer_idx = 0;
+      for (c = 0; c < (int)lbp_num; c++) {
+        if (LBPs[lbp_idxes[c]].bg_layer_num == 1) {
+          first_layer_idx = c;
+          break;
+        }
+      }
+      if (bg_layer_num > 1 && DistLBP(&(LBPs[lbp_idxes[0]]), &(LBPs[first_layer_idx])) > 0.1f) {
+        for (c = 0; c < channels; c++)
+          *_bg_ml_imgD++ = (uchar)(layer_colors[bg_layer_num].val[c]);
+        bLayeredBg = true;
+      }
+
+      if (!bLayeredBg)
+        _bg_ml_imgD += channels;
+    }
+    else {
+      _bg_ml_imgD += channels;
+    }
+
+    PLBP++;
+    _fg_maskD++;
+  }
+
+  ODC.SetImageData(bg_multi_layer_img, bg_ml_imgD);
+
+  delete[] fg_maskD;
+  delete[] bg_ml_imgD;
+}
+
+void CMultiLayerBGS::GetForegroundProbabilityImage(IplImage *fg_dist_img) {
+  COpencvDataConversion<float, float> ODC1;
+  COpencvDataConversion<uchar, uchar> ODC2;
+
+  float *_fg_distD = ODC1.GetImageData(m_pBgDistImg);
+  uchar *_fg_progI = ODC2.GetImageData(fg_dist_img);
+  float *fg_distD = _fg_distD;
+  uchar *fg_progI = _fg_progI;
+
+  /*
+  float *fg_distD = (float*)(m_pBgDistImg->imageData);
+  uchar *fg_progI = (uchar*)(fg_dist_img->imageData);
+  */
+
+  int channels = fg_dist_img->nChannels;
+
+  int a, b;
+  int img_length = fg_dist_img->width * fg_dist_img->height;
+  uchar temp;
+  for (a = 0; a < img_length; a++) {
+    temp = cvRound(255.0f * ((*fg_distD++)));
+    for (b = 0; b < channels; b++)
+      *fg_progI++ = temp;
+  }
+
+  ODC2.SetImageData(fg_dist_img, _fg_progI);
+
+  delete[] _fg_distD;
+  delete[] _fg_progI;
+}
+
+void CMultiLayerBGS::RemoveBackgroundLayers(PixelLBPStruct *PLBP, bool *removed_modes) {
+  int a, b;
+  int lbp_num = PLBP->num;
+
+  /*
+  if ( lbp_num < m_nMaxLBPModeNum )
+  return;
+  */
+
+  /* testing */
+
+  unsigned short* lbp_idxes = PLBP->lbp_idxes;
+  if (!removed_modes) {
+    int removed_bg_layer_num = 0;
+    for (a = 0; a < lbp_num; a++) {
+      if (PLBP->LBPs[lbp_idxes[a]].bg_layer_num && PLBP->LBPs[lbp_idxes[a]].weight < m_fMinBgLayerWeight) { // should be removed
+        removed_bg_layer_num = PLBP->LBPs[lbp_idxes[a]].bg_layer_num;
+        lbp_num--;
+        for (b = a; b < lbp_num; b++)
+          lbp_idxes[b] = lbp_idxes[b + 1];
+        break;
+      }
+    }
+    if (removed_bg_layer_num) {
+      for (a = 0; a < lbp_num; a++) {
+        if (PLBP->LBPs[lbp_idxes[a]].bg_layer_num > removed_bg_layer_num)
+          PLBP->LBPs[lbp_idxes[a]].bg_layer_num--;
+      }
+    }
+  }
+  else {
+    int removed_bg_layer_nums[10];
+    int removed_layer_num = 0;
+    for (a = 0; a < lbp_num; a++) {
+      if (removed_modes[a] && PLBP->LBPs[lbp_idxes[a]].bg_layer_num) { // should be removed
+        removed_bg_layer_nums[removed_layer_num++] = PLBP->LBPs[lbp_idxes[a]].bg_layer_num;
+      }
+    }
+
+    for (a = 0; a < lbp_num; a++) {
+      if (removed_modes[a]) { // should be removed
+        lbp_num--;
+        for (b = a; b < lbp_num; b++)
+          lbp_idxes[b] = lbp_idxes[b + 1];
+      }
+    }
+
+    for (a = 0; a < lbp_num; a++) {
+      for (b = 0; b < removed_layer_num; b++) {
+        if (PLBP->LBPs[lbp_idxes[a]].bg_layer_num > removed_bg_layer_nums[b])
+          PLBP->LBPs[lbp_idxes[a]].bg_layer_num--;
+      }
+    }
+  }
+
+  // sort the list of modes based on the weights of modes
+  if (lbp_num != (int)PLBP->num) {
+    float weights[100], tot_weights = 0;
+    for (a = 0; a < (int)lbp_num; a++) {
+      weights[a] = PLBP->LBPs[lbp_idxes[a]].weight;
+      tot_weights += weights[a];
+    }
+
+    // sort weights in the descent order
+    QuickSort(weights, lbp_idxes, 0, (int)lbp_num - 1, false);
+
+    // calculate the first potential background modes number, bg_num
+    float threshold_weight = m_fBackgroundModelPercent*tot_weights;
+    int bg_num = 0;
+    tot_weights = 0;
+    for (a = 0; a < (int)lbp_num; a++) {
+      tot_weights += PLBP->LBPs[lbp_idxes[a]].weight;
+      if (tot_weights > threshold_weight) {
+        bg_num = a + 1;
+        break;
+      }
+    }
+    (*PLBP).bg_num = bg_num;
+
+  }
+
+  PLBP->num = lbp_num;
+
+  float bg_layer_data[10];
+  unsigned short bg_layer_idxes[10];
+  int bg_layer_num;
+  int tot_bg_layer_num = 0;
+  for (a = 0; a < lbp_num; a++) {
+    bg_layer_num = PLBP->LBPs[lbp_idxes[a]].bg_layer_num;
+    if (bg_layer_num) {
+      bg_layer_data[tot_bg_layer_num] = (float)bg_layer_num;
+      bg_layer_idxes[tot_bg_layer_num++] = lbp_idxes[a];
+    }
+  }
+  if (tot_bg_layer_num == 1) {
+    PLBP->LBPs[bg_layer_idxes[0]].bg_layer_num = 1;
+  }
+  else if (tot_bg_layer_num) {
+    // sort weights in the descent order
+    QuickSort(bg_layer_data, bg_layer_idxes, 0, tot_bg_layer_num - 1, true);
+    for (a = 0; a < tot_bg_layer_num; a++)
+      PLBP->LBPs[bg_layer_idxes[a]].bg_layer_num = a + 1;
+  }
+
+  /*
+  int max_bg_layer_num = 0;
+  for ( a = 0 ; a < lbp_num ; a++ )
+  max_bg_layer_num = MAX(max_bg_layer_num, PLBP->LBPs[lbp_idxes[a]].bg_layer_num);
+  if ( max_bg_layer_num >= 2 ) {
+  bool find_first_layer = false;
+  for ( a = 0 ; a < lbp_num ; a++ ) {
+  max_bg_layer_num = MAX(max_bg_layer_num, PLBP->LBPs[lbp_idxes[a]].bg_layer_num);
+  if ( PLBP->LBPs[lbp_idxes[a]].bg_layer_num == 1 ) {
+  find_first_layer = true;
+  break;
+  }
+  }
+  if ( !find_first_layer ) {
+  printf("\n===============================================\n");
+  printf(" have second layer, no first layer \n");
+  printf("\n===============================================\n");
+  exit(1);
+  }
+  }
+  */
+}
+
+void CMultiLayerBGS::Postprocessing() {
+  // post-processing for background subtraction results
+  cvDilate(m_pFgMaskImg, m_pFgMaskImg, 0, 2);
+  cvErode(m_pFgMaskImg, m_pFgMaskImg, 0, 2);
+
+  /** Example of extracting and filtering the blobs of an image */
+
+  // object that will contain blobs of inputImage
+  CBlobResult blobs;
+
+  IplImage *inputImage = m_pFgMaskImg;
+
+  // Extract the blobs using a threshold of 100 in the image
+  blobs = CBlobResult(inputImage, NULL, 0, true);
+
+  // create a file with some of the extracted features
+  //blobs.PrintBlobs( ".\\blobs.txt" );
+
+  // discard the blobs with less area than 100 pixels
+  // ( the criteria to filter can be any class derived from COperadorBlob )
+  blobs.Filter(blobs, B_INCLUDE, CBlobGetArea(), B_GREATER, 100);
+
+  // create a file with filtered results
+  //blobs.PrintBlobs( ".\\filteredBlobs.txt" );
+
+  // build an output image equal to the input but with 3 channels (to draw the coloured blobs)
+  IplImage *outputImage;
+  outputImage = cvCreateImage(cvSize(inputImage->width, inputImage->height), IPL_DEPTH_8U, 1);
+  cvSet(outputImage, cvScalar(0));
+
+  // plot the selected blobs in a output image
+  CBlob filtered_blob;
+  //cvSet(outputImage, CV_RGB(0,0,255));
+  int a;
+  for (a = 0; a < blobs.GetNumBlobs(); a++) {
+    filtered_blob = blobs.GetBlob(a);
+    filtered_blob.FillBlob(outputImage, cvScalar(255));
+  }
+  blobs.GetNthBlob(CBlobGetArea(), 0, filtered_blob);
+  filtered_blob.FillBlob(outputImage, cvScalar(0));
+
+  /*
+  char *win_name = "blob filtered image";
+  cvNamedWindow(win_name);
+  cvShowImage(win_name, outputImage);
+  cvWaitKey(3);
+  */
+
+  cvReleaseImage(&outputImage);
+}
+
+void CMultiLayerBGS::GetFloatEdgeImage(IplImage *src, IplImage *dst) {
+  if (src->nChannels > 1) {
+    printf("Error: the input source image must be single-channel image!\n");
+    exit(1);
+  }
+  if (dst->depth != IPL_DEPTH_32F) {
+    printf("Error: the output edge image must be float image ranging in [0,1]!\n");
+    exit(1);
+  }
+
+  uchar *src_x_data;
+  float *dst_x_data;
+
+  int x, y;
+  for (y = 0; y < dst->height; y++) {
+    src_x_data = (uchar*)(src->imageData + src->widthStep * y);
+    dst_x_data = (float*)(dst->imageData + dst->widthStep * y);
+    for (x = 0; x < dst->width; x++) {
+      *dst_x_data++ = (float)(*src_x_data++) / 255.0f;
+    }
+  }
+}
+
+void CMultiLayerBGS::ExportLogMessage(char *msg) {
+  const char *log_fn = "log_message.txt";
+  ofstream fout(log_fn, ios::app);
+  if (fout.fail()) {
+    printf("Error opening log output file %s.\n", log_fn);
+    fout.close();
+    exit(0);
+  }
+
+  fout << msg;
+  fout.close();
+}
+
+void CMultiLayerBGS::UpdatePatternColorDistWeights(float *cur_pattern, float *bg_pattern) {
+  return;
+
+  int cur_true_num = 0, cur_false_num = 0, bg_true_num = 0, bg_false_num = 0;
+  int a;
+
+  for (a = 0; a < m_nLBPLength; a++) {
+    cur_true_num += (cur_pattern[a] > 0.5f ? 1 : 0);
+    cur_false_num += (cur_pattern[a] < 0.5f ? 0 : 1);
+    bg_true_num += (bg_pattern[a] > 0.5f);
+    bg_false_num += (bg_pattern[a] < 0.5f);
+  }
+  m_fTextureWeight = expf(-(fabsf(cur_true_num - cur_false_num) + fabsf(bg_true_num - bg_false_num) + 0.8f) / (float)m_nLBPLength);
+  m_fTextureWeight = MAX(MIN(m_fTextureWeight, 0.5f), 0.1f);
+  m_fColorWeight = 1.0f - m_fTextureWeight;
+}
+
+void CMultiLayerBGS::Save(const char *bg_model_fn) {
+  Save(bg_model_fn, 2);
+}
+
+void CMultiLayerBGS::Save(const char *bg_model_fn, int save_type) {
+  FILE * fout = fopen(bg_model_fn, "w");
+  if (!fout) {
+    printf("Error opening background model output file %s.\n", bg_model_fn);
+    fclose(fout);
+    //exit(0);
+    return;
+  }
+
+  int i, j;
+  if (save_type == 0) { /* save the background model information */
+    fprintf(fout, "FILE_TYPE:  MODEL_INFO\n\n");
+
+    fprintf(fout, "MAX_MODEL_NUM: %5d\n", m_nMaxLBPModeNum);
+    fprintf(fout, "LBP_LENGTH: %5d\n", m_nLBPLength);
+    fprintf(fout, "CHANNELS_NUM: %5d\n", m_nChannel);
+    fprintf(fout, "IMAGE_SIZE: %5d %5d\n\n", m_cvImgSize.width, m_cvImgSize.height);
+
+    fprintf(fout, "MODEL_INFO_PIXEL_BY_PIXEL:\n");
+
+    int img_length = m_cvImgSize.height * m_cvImgSize.width;
+    PixelLBPStruct* PLBP = m_pPixelLBPs;
+
+    for (int yx = 0; yx < img_length; yx++) {
+      fprintf(fout, "%3d %3d %3d", (*PLBP).num, (*PLBP).bg_num, (*PLBP).cur_bg_layer_no);
+      for (i = 0; i < (int)(*PLBP).num; i++)
+        fprintf(fout, " %3d", (*PLBP).lbp_idxes[i]);
+      for (i = 0; i < (int)(*PLBP).num; i++) {
+        int li = (*PLBP).lbp_idxes[i];
+        for (j = 0; j < m_nChannel; j++) {
+          fprintf(fout, " %7.1f %7.1f %7.1f", (*PLBP).LBPs[li].bg_intensity[j],
+            (*PLBP).LBPs[li].max_intensity[j], (*PLBP).LBPs[li].min_intensity[j]);
+        }
+        for (j = 0; j < m_nLBPLength; j++)
+          fprintf(fout, " %7.3f", (*PLBP).LBPs[li].bg_pattern[j]);
+        fprintf(fout, " %10.5f", (*PLBP).LBPs[li].weight);
+        fprintf(fout, " %10.5f", (*PLBP).LBPs[li].max_weight);
+        fprintf(fout, " %3d", (*PLBP).LBPs[li].bg_layer_num);
+        fprintf(fout, " %20lu", (*PLBP).LBPs[li].first_time);
+        fprintf(fout, " %20lu", (*PLBP).LBPs[li].last_time);
+        fprintf(fout, " %8d", (*PLBP).LBPs[li].freq);
+      }
+      fprintf(fout, "\n");
+      PLBP++;
+    }
+  }
+  else if (save_type == 1) { /* save current parameters for background subtraction */
+    fprintf(fout, "FILE_TYPE:  MODEL_PARAS\n\n");
+
+    fprintf(fout, "MAX_MODEL_NUM: %5d\n", m_nMaxLBPModeNum);
+    fprintf(fout, "FRAME_DURATION: %f\n", m_fFrameDuration);
+    fprintf(fout, "MODEL_UPDATING_LEARN_RATE: %f\n", m_fModeUpdatingLearnRate);
+    fprintf(fout, "WEIGHT_UPDATING_LEARN_RATE: %f\n", m_fWeightUpdatingLearnRate);
+    fprintf(fout, "WEIGHT_UPDATING_CONSTANT: %f\n", m_fWeightUpdatingConstant);
+    fprintf(fout, "LOW_INITIAL_MODE_WEIGHT: %f\n", m_fLowInitialModeWeight);
+    fprintf(fout, "RELIABLE_BACKGROUND_MODE_WEIGHT: %f\n", m_fReliableBackgroundModeWeight);
+    fprintf(fout, "ROBUST_COLOR_OFFSET: %f\n", m_fRobustColorOffset);
+    fprintf(fout, "BACKGROUND_MODEL_PERCENT: %f\n", m_fBackgroundModelPercent);
+    fprintf(fout, "ROBUST_SHADOW_RATE: %f\n", m_fRobustShadowRate);
+    fprintf(fout, "ROBUST_HIGHLIGHT_RATE: %f\n", m_fRobustHighlightRate);
+    fprintf(fout, "PATTERN_COLOR_DIST_BACKGROUND_THRESHOLD: %f\n", m_fPatternColorDistBgThreshold);
+    fprintf(fout, "PATTERN_COLOR_DIST_BACKGROUND_UPDATED_THRESHOLD: %f\n", m_fPatternColorDistBgUpdatedThreshold);
+    fprintf(fout, "MIN_BACKGROUND_LAYER_WEIGHT: %f\n", m_fMinBgLayerWeight);
+    fprintf(fout, "PATTERN_DIST_SMOOTH_NEIG_HALF_SIZE: %d\n", m_nPatternDistSmoothNeigHalfSize);
+    fprintf(fout, "PATTERN_DIST_CONV_GAUSSIAN_SIGMA: %f\n", m_fPatternDistConvGaussianSigma);
+    fprintf(fout, "TEXTURE_WEIGHT: %f\n", m_fTextureWeight);
+    fprintf(fout, "MIN_NOISED_ANGLE: %f\n", m_fMinNoisedAngle);
+    fprintf(fout, "MIN_NOISED_ANGLE_SINE: %f\n", m_fMinNoisedAngleSine);
+    fprintf(fout, "BILATERAL_SIGMA_S: %f\n", m_fSigmaS);
+    fprintf(fout, "BILATERAL_SIGMA_R: %f\n", m_fSigmaR);
+    fprintf(fout, "LBP_LENGTH: %5d\n", m_nLBPLength);
+    fprintf(fout, "LBP_LEVEL_NUM: %5d\n", m_nLBPLevelNum);
+    fprintf(fout, "LBP_RADIUSES: ");
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fprintf(fout, "%10.5f", m_pLBPRadiuses[i]);
+    fprintf(fout, "\nLBP_NEIG_POINT_NUMS: ");
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fprintf(fout, "%6d", m_pLBPMeigPointNums[i]);
+  }
+  else if (save_type == 2) { /* save the background model information and parameters */
+    fprintf(fout, "FILE_TYPE:  MODEL_PARAS_INFO\n\n");
+
+    fprintf(fout, "MAX_MODEL_NUM: %5d\n", m_nMaxLBPModeNum);
+    fprintf(fout, "FRAME_DURATION: %f\n", m_fFrameDuration);
+    fprintf(fout, "MODEL_UPDATING_LEARN_RATE: %f\n", m_fModeUpdatingLearnRate);
+    fprintf(fout, "WEIGHT_UPDATING_LEARN_RATE: %f\n", m_fWeightUpdatingLearnRate);
+    fprintf(fout, "WEIGHT_UPDATING_CONSTANT: %f\n", m_fWeightUpdatingConstant);
+    fprintf(fout, "LOW_INITIAL_MODE_WEIGHT: %f\n", m_fLowInitialModeWeight);
+    fprintf(fout, "RELIABLE_BACKGROUND_MODE_WEIGHT: %f\n", m_fReliableBackgroundModeWeight);
+    fprintf(fout, "ROBUST_COLOR_OFFSET: %f\n", m_fRobustColorOffset);
+    fprintf(fout, "BACKGROUND_MODEL_PERCENT: %f\n", m_fBackgroundModelPercent);
+    fprintf(fout, "ROBUST_SHADOW_RATE: %f\n", m_fRobustShadowRate);
+    fprintf(fout, "ROBUST_HIGHLIGHT_RATE: %f\n", m_fRobustHighlightRate);
+    fprintf(fout, "PATTERN_COLOR_DIST_BACKGROUND_THRESHOLD: %f\n", m_fPatternColorDistBgThreshold);
+    fprintf(fout, "PATTERN_COLOR_DIST_BACKGROUND_UPDATED_THRESHOLD: %f\n", m_fPatternColorDistBgUpdatedThreshold);
+    fprintf(fout, "MIN_BACKGROUND_LAYER_WEIGHT: %f\n", m_fMinBgLayerWeight);
+    fprintf(fout, "PATTERN_DIST_SMOOTH_NEIG_HALF_SIZE: %d\n", m_nPatternDistSmoothNeigHalfSize);
+    fprintf(fout, "PATTERN_DIST_CONV_GAUSSIAN_SIGMA: %f\n", m_fPatternDistConvGaussianSigma);
+    fprintf(fout, "TEXTURE_WEIGHT: %f\n", m_fTextureWeight);
+    fprintf(fout, "MIN_NOISED_ANGLE: %f\n", m_fMinNoisedAngle);
+    fprintf(fout, "MIN_NOISED_ANGLE_SINE: %f\n", m_fMinNoisedAngleSine);
+    fprintf(fout, "BILATERAL_SIGMA_S: %f\n", m_fSigmaS);
+    fprintf(fout, "BILATERAL_SIGMA_R: %f\n", m_fSigmaR);
+    fprintf(fout, "LBP_LENGTH: %5d\n", m_nLBPLength);
+    fprintf(fout, "LBP_LEVEL_NUM: %5d\n", m_nLBPLevelNum);
+    fprintf(fout, "LBP_RADIUSES: ");
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fprintf(fout, "%10.5f", m_pLBPRadiuses[i]);
+    fprintf(fout, "\nLBP_NEIG_POINT_NUMS: ");
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fprintf(fout, "%6d", m_pLBPMeigPointNums[i]);
+
+    fprintf(fout, "\nMAX_MODEL_NUM: %5d\n", m_nMaxLBPModeNum);
+    fprintf(fout, "LBP_LENGTH: %5d\n", m_nLBPLength);
+    fprintf(fout, "CHANNELS_NUM: %5d\n", m_nChannel);
+    fprintf(fout, "IMAGE_SIZE: %5d %5d\n\n", m_cvImgSize.width, m_cvImgSize.height);
+
+    fprintf(fout, "MODEL_INFO_PIXEL_BY_PIXEL:\n");
+
+    int img_length = m_cvImgSize.height * m_cvImgSize.width;
+    PixelLBPStruct* PLBP = m_pPixelLBPs;
+
+    for (int yx = 0; yx < img_length; yx++) {
+      fprintf(fout, "%3d %3d %3d", (*PLBP).num, (*PLBP).bg_num, (*PLBP).cur_bg_layer_no);
+      for (i = 0; i < (int)(*PLBP).num; i++)
+        fprintf(fout, " %3d", (*PLBP).lbp_idxes[i]);
+      for (i = 0; i < (int)(*PLBP).num; i++) {
+        int li = (*PLBP).lbp_idxes[i];
+        for (j = 0; j < m_nChannel; j++) {
+          fprintf(fout, " %7.1f %7.1f %7.1f", (*PLBP).LBPs[li].bg_intensity[j],
+            (*PLBP).LBPs[li].max_intensity[j], (*PLBP).LBPs[li].min_intensity[j]);
+        }
+        for (j = 0; j < m_nLBPLength; j++)
+          fprintf(fout, " %7.3f", (*PLBP).LBPs[li].bg_pattern[j]);
+        fprintf(fout, " %10.5f", (*PLBP).LBPs[li].weight);
+        fprintf(fout, " %10.5f", (*PLBP).LBPs[li].max_weight);
+        fprintf(fout, " %3d", (*PLBP).LBPs[li].bg_layer_num);
+        fprintf(fout, " %20lu", (*PLBP).LBPs[li].first_time);
+        fprintf(fout, " %20lu", (*PLBP).LBPs[li].last_time);
+        fprintf(fout, " %8d", (*PLBP).LBPs[li].freq);
+      }
+      fprintf(fout, "\n");
+      PLBP++;
+    }
+  }
+  else { /* wrong save type */
+    printf("Please input correct save type: 0 - model_info  1 - model_paras  2 - model_paras_info\n");
+    fclose(fout);
+    exit(0);
+  }
+
+  fclose(fout);
+}
+
+bool CMultiLayerBGS::Load(const char *bg_model_fn) {
+  ifstream fin(bg_model_fn, ios::in);
+  if (fin.fail()) {
+    printf("Error opening background model file %s.\n", bg_model_fn);
+    fin.close();
+    return false;
+  }
+
+  char para_name[1024], model_type[1024];
+
+  fin >> para_name >> model_type;
+
+  int i, j;
+  CvSize img_size;
+  int img_length = m_cvImgSize.width * m_cvImgSize.height;
+  int max_lbp_mode_num = m_nMaxLBPModeNum;
+
+  if (!strcmp(model_type, "MODEL_INFO")) {
+    fin >> para_name >> m_nMaxLBPModeNum;
+    fin >> para_name >> m_nLBPLength;
+    fin >> para_name >> m_nChannel;
+    fin >> para_name >> img_size.width >> img_size.height;
+
+    if (m_cvImgSize.width != img_size.width || m_cvImgSize.height != img_size.height) {
+      printf("Image size is not matched!\n");
+      return false;
+    }
+
+    if (max_lbp_mode_num != m_nMaxLBPModeNum) {
+      PixelLBPStruct* PLBP = m_pPixelLBPs;
+      for (int yx = 0; yx < img_length; yx++) {
+        delete[](*PLBP).LBPs;
+        delete[](*PLBP).lbp_idxes;
+        (*PLBP).LBPs = new LBPStruct[m_nMaxLBPModeNum];
+        (*PLBP).lbp_idxes = new unsigned short[m_nMaxLBPModeNum];
+      }
+    }
+
+    fin >> para_name;
+
+    int img_length = m_cvImgSize.height * m_cvImgSize.width;
+    PixelLBPStruct* PLBP = m_pPixelLBPs;
+
+    for (int yx = 0; yx < img_length; yx++) {
+      fin >> (*PLBP).num >> (*PLBP).bg_num >> (*PLBP).cur_bg_layer_no;
+      for (i = 0; i < (int)(*PLBP).num; i++)
+        fin >> (*PLBP).lbp_idxes[i];
+      for (i = 0; i < (int)(*PLBP).num; i++) {
+        int li = (*PLBP).lbp_idxes[i];
+        for (j = 0; j < m_nChannel; j++) {
+          fin >> (*PLBP).LBPs[li].bg_intensity[j] >>
+            (*PLBP).LBPs[li].max_intensity[j] >> (*PLBP).LBPs[li].min_intensity[j];
+        }
+        for (j = 0; j < m_nLBPLength; j++)
+          fin >> (*PLBP).LBPs[li].bg_pattern[j];
+        fin >> (*PLBP).LBPs[li].weight >> (*PLBP).LBPs[li].max_weight >> (*PLBP).LBPs[li].bg_layer_num
+          >> (*PLBP).LBPs[li].first_time >> (*PLBP).LBPs[li].last_time >> (*PLBP).LBPs[li].freq;
+      }
+      PLBP++;
+    }
+  }
+  else if (!strcmp(model_type, "MODEL_PARAS")) {
+    fin >> para_name >> m_nMaxLBPModeNum;
+    fin >> para_name >> m_fFrameDuration;
+    fin >> para_name >> m_fModeUpdatingLearnRate;
+    fin >> para_name >> m_fWeightUpdatingLearnRate;
+    fin >> para_name >> m_fWeightUpdatingConstant;
+    fin >> para_name >> m_fLowInitialModeWeight;
+    fin >> para_name >> m_fReliableBackgroundModeWeight;
+    fin >> para_name >> m_fRobustColorOffset;
+    fin >> para_name >> m_fBackgroundModelPercent;
+    fin >> para_name >> m_fRobustShadowRate;
+    fin >> para_name >> m_fRobustHighlightRate;
+    fin >> para_name >> m_fPatternColorDistBgThreshold;
+    fin >> para_name >> m_fPatternColorDistBgUpdatedThreshold;
+    fin >> para_name >> m_fMinBgLayerWeight;
+    fin >> para_name >> m_nPatternDistSmoothNeigHalfSize;
+    fin >> para_name >> m_fPatternDistConvGaussianSigma;
+    fin >> para_name >> m_fTextureWeight;
+    fin >> para_name >> m_fMinNoisedAngle;
+    fin >> para_name >> m_fMinNoisedAngleSine;
+    fin >> para_name >> m_fSigmaS;
+    fin >> para_name >> m_fSigmaR;
+    fin >> para_name >> m_nLBPLength;
+    fin >> para_name >> m_nLBPLevelNum;
+    fin >> para_name;
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fin >> m_pLBPRadiuses[i];
+    fin >> para_name;
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fin >> m_pLBPMeigPointNums[i];
+  }
+  else if (!strcmp(model_type, "MODEL_PARAS_INFO")) {
+    fin >> para_name >> m_nMaxLBPModeNum;
+    fin >> para_name >> m_fFrameDuration;
+    fin >> para_name >> m_fModeUpdatingLearnRate;
+    fin >> para_name >> m_fWeightUpdatingLearnRate;
+    fin >> para_name >> m_fWeightUpdatingConstant;
+    fin >> para_name >> m_fLowInitialModeWeight;
+    fin >> para_name >> m_fReliableBackgroundModeWeight;
+    fin >> para_name >> m_fRobustColorOffset;
+    fin >> para_name >> m_fBackgroundModelPercent;
+    fin >> para_name >> m_fRobustShadowRate;
+    fin >> para_name >> m_fRobustHighlightRate;
+    fin >> para_name >> m_fPatternColorDistBgThreshold;
+    fin >> para_name >> m_fPatternColorDistBgUpdatedThreshold;
+    fin >> para_name >> m_fMinBgLayerWeight;
+    fin >> para_name >> m_nPatternDistSmoothNeigHalfSize;
+    fin >> para_name >> m_fPatternDistConvGaussianSigma;
+    fin >> para_name >> m_fTextureWeight;
+    fin >> para_name >> m_fMinNoisedAngle;
+    fin >> para_name >> m_fMinNoisedAngleSine;
+    fin >> para_name >> m_fSigmaS;
+    fin >> para_name >> m_fSigmaR;
+    fin >> para_name >> m_nLBPLength;
+    fin >> para_name >> m_nLBPLevelNum;
+    fin >> para_name;
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fin >> m_pLBPRadiuses[i];
+    fin >> para_name;
+    for (i = 0; i < m_nLBPLevelNum; i++)
+      fin >> m_pLBPMeigPointNums[i];
+
+    fin >> para_name >> m_nMaxLBPModeNum;
+    fin >> para_name >> m_nLBPLength;
+    fin >> para_name >> m_nChannel;
+    fin >> para_name >> img_size.width >> img_size.height;
+
+    if (m_cvImgSize.width != img_size.width || m_cvImgSize.height != img_size.height) {
+      printf("Image size is not matched!\n");
+      return false;
+    }
+
+    if (max_lbp_mode_num != m_nMaxLBPModeNum) {
+      PixelLBPStruct* PLBP = m_pPixelLBPs;
+      for (int yx = 0; yx < img_length; yx++) {
+        delete[](*PLBP).LBPs;
+        delete[](*PLBP).lbp_idxes;
+        (*PLBP).LBPs = new LBPStruct[m_nMaxLBPModeNum];
+        (*PLBP).lbp_idxes = new unsigned short[m_nMaxLBPModeNum];
+      }
+    }
+
+    fin >> para_name;
+
+    int img_length = m_cvImgSize.height * m_cvImgSize.width;
+    PixelLBPStruct* PLBP = m_pPixelLBPs;
+
+    for (int yx = 0; yx < img_length; yx++) {
+      fin >> (*PLBP).num >> (*PLBP).bg_num >> (*PLBP).cur_bg_layer_no;
+      for (i = 0; i < (int)(*PLBP).num; i++)
+        fin >> (*PLBP).lbp_idxes[i];
+      for (i = 0; i < (int)(*PLBP).num; i++) {
+        int li = (*PLBP).lbp_idxes[i];
+        for (j = 0; j < m_nChannel; j++) {
+          fin >> (*PLBP).LBPs[li].bg_intensity[j] >>
+            (*PLBP).LBPs[li].max_intensity[j] >> (*PLBP).LBPs[li].min_intensity[j];
+        }
+        for (j = 0; j < m_nLBPLength; j++)
+          fin >> (*PLBP).LBPs[li].bg_pattern[j];
+        fin >> (*PLBP).LBPs[li].weight >> (*PLBP).LBPs[li].max_weight >> (*PLBP).LBPs[li].bg_layer_num
+          >> (*PLBP).LBPs[li].first_time >> (*PLBP).LBPs[li].last_time >> (*PLBP).LBPs[li].freq;
+      }
+      PLBP++;
+    }
+  }
+  else {
+    printf("Not correct model save type!\n");
+    fin.close();
+    exit(0);
+  }
+
+  fin.close();
+
+  ResetAllParameters();
+
+  return true;
+}
+
+void CMultiLayerBGS::SetValidPointMask(IplImage *maskImage, int mode) {
+  if (mode == 1)
+    SetBkMaskImage(maskImage);
+  else
+    cvAnd(m_pBkMaskImg, maskImage, m_pBkMaskImg);
+}
+
+void CMultiLayerBGS::SetFrameRate(float frameDuration) {
+  m_fModeUpdatingLearnRate = m_fModeUpdatingLearnRatePerSecond*frameDuration;
+  m_fWeightUpdatingLearnRate = m_fWeightUpdatingLearnRatePerSecond*frameDuration;
+
+  m_fFrameDuration = frameDuration;
+
+  m_f1_ModeUpdatingLearnRate = 1.0f - m_fModeUpdatingLearnRate;
+  m_f1_WeightUpdatingLearnRate = 1.0f - m_fWeightUpdatingLearnRate;
+}
+
+void CMultiLayerBGS::Init(int width, int height) {
+  IplImage* first_img = cvCreateImage(cvSize(width, height), IPL_DEPTH_8U, 3);
+  int lbp_level_num = 1;
+  float radiuses[] = { 2.0f };
+  int neig_pt_nums[] = { 6 };
+  Initialization(first_img, lbp_level_num, radiuses, neig_pt_nums);
+  cvReleaseImage(&first_img);
+}
+
+int CMultiLayerBGS::SetRGBInputImage(IplImage *inputImage, CvRect *roi) {
+  if (!inputImage) {
+    printf("Please allocate the IplImage memory!\n");
+    return 0;
+  }
+  if (inputImage->width != m_cvImgSize.width ||
+    inputImage->height != m_cvImgSize.height ||
+    inputImage->depth != IPL_DEPTH_8U ||
+    inputImage->nChannels != 3) {
+    printf("Please provide the correct IplImage pointer, \ne.g. inputImage = cvCreateImage(imgSize, IPL_DEPTH_8U, 3);\n");
+    return 0;
+  }
+  SetNewImage(inputImage, roi);
+  return 1;
+}
+
+void CMultiLayerBGS::SetParameters(int max_lbp_mode_num, float mode_updating_learn_rate_per_second, float weight_updating_learn_rate_per_second, float low_init_mode_weight) {
+  m_nMaxLBPModeNum = max_lbp_mode_num;
+  m_fModeUpdatingLearnRate = mode_updating_learn_rate_per_second*m_fFrameDuration;
+  m_fWeightUpdatingLearnRate = weight_updating_learn_rate_per_second*m_fFrameDuration;
+  m_fLowInitialModeWeight = low_init_mode_weight;
+
+  m_fModeUpdatingLearnRatePerSecond = mode_updating_learn_rate_per_second;
+  m_fWeightUpdatingLearnRatePerSecond = weight_updating_learn_rate_per_second;
+
+  m_f1_ModeUpdatingLearnRate = 1.0f - m_fModeUpdatingLearnRate;
+  m_f1_WeightUpdatingLearnRate = 1.0f - m_fWeightUpdatingLearnRate;
+}
+
+int CMultiLayerBGS::Process() {
+  BackgroundSubtractionProcess();
+  return 1;
+}
+
+int CMultiLayerBGS::SetForegroundMaskImage(IplImage* fg_mask_img) {
+  if (!fg_mask_img) {
+    printf("Please allocate the IplImage memory!\n");
+    return 0;
+  }
+  if (fg_mask_img->width != m_cvImgSize.width ||
+    fg_mask_img->height != m_cvImgSize.height ||
+    fg_mask_img->depth != IPL_DEPTH_8U ||
+    fg_mask_img->nChannels != 1) {
+    printf("Please provide the correct IplImage pointer, \ne.g. fg_mask_img = cvCreateImage(imgSize, IPL_DEPTH_8U, 1);\n");
+    return 0;
+  }
+
+  m_pFgMaskImg = fg_mask_img;
+
+  return 1;
+}
+
+int CMultiLayerBGS::SetForegroundProbImage(IplImage* fg_prob_img) {
+  if (!fg_prob_img) {
+    printf("Please allocate the IplImage memory!\n");
+    return 0;
+  }
+  if (fg_prob_img->width != m_cvImgSize.width ||
+    fg_prob_img->height != m_cvImgSize.height ||
+    fg_prob_img->depth != IPL_DEPTH_8U) {
+    printf("Please provide the correct IplImage pointer, \ne.g. fg_prob_img = cvCreateImage(imgSize, IPL_DEPTH_8U, 1);\n");
+    return 0;
+  }
+
+  m_pFgProbImg = fg_prob_img;
+
+  return 1;
+}
+
+void CMultiLayerBGS::SetCurrentFrameNumber(unsigned long cur_frame_no) {
+  m_nCurImgFrameIdx = cur_frame_no;
+}

--- a/package_bgs/jmo/CMultiLayerBGS.h
+++ b/package_bgs/jmo/CMultiLayerBGS.h
@@ -1,0 +1,313 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// BackgroundSubtraction.h: interface for the CBackgroundSubtraction class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(_MULTI_LAYER_BGS_H_)
+#define _MULTI_LAYER_BGS_H_
+
+/*
+Since the used fast cross bilateral filter codes can not be compiled under Windows,
+we don't use the bilateral filter to remove the noise in the foreground detection
+step. If you compile it under Linux, please uncomment it.
+*/
+//#define LINUX_BILATERAL_FILTER
+
+#include "LocalBinaryPattern.h"
+#include "BGS.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include "BlobResult.h"
+#include "OpenCvDataConversion.h"
+
+#include "BackgroundSubtractionAPI.h"
+
+#ifdef LINUX_BILATERAL_FILTER
+#include "CrossBilateralFilter.h"				// cross bilateral filter
+#endif
+
+#include <ctime>						// clock
+#include <cstdlib>						// C standard library
+#include <cstdio>						// C I/O (for sscanf)
+#include <cstring>						// string manipulation
+#include <fstream>						// file I/O
+#include <cmath>						// math includes
+#include <iostream>						// I/O streams
+
+using namespace std;						// make std:: accessible
+
+class CMultiLayerBGS : public CBackgroundSubtractionAPI
+{
+public:
+  //-------------------------------------------------------------
+  // TO CALL AT INITIALISATION: DEFINES THE SIZE OF THE INPUT IMAGES
+  // NORMALLY, UNNECESSARY IF A CONFIGURATION FILE IS LOADED
+  void   Init(int width, int height);
+
+  //-------------------------------------------------------------
+  // PROVIDE A MASK TO DEFINE THE SET OF POINTS WHERE BACKGROUND
+  // SUBTRACTION DOES NOT NEED TO BE PERFORMED
+  //
+  //  mode is useful to specify if the points to remove from
+  //  processing are in addition to the ones potentially
+  //  removed according to the configuration file,
+  //  or if they are the only ones to be removed
+  //
+  // mode=0 : provided points need to be removed
+  //          in addition to those already removed
+  // mode=1 : the provided points are the only one to remove
+  //          from processing
+  // Note:  maskImage(li,co)=0 indicate the points to remove
+  //       from background processing
+  void   SetValidPointMask(IplImage* maskImage, int mode);
+
+  //-------------------------------------------------------------
+  //
+  //   set the frame rate, to adjust the update parameters
+  //   to the actual frame rate.
+  //   Can be called only once at initialisation,
+  //   but in online cases, can be used to indicate
+  //   the time interval during the last processed frame
+  //
+  //   frameDuration is in millisecond
+  void   SetFrameRate(float    frameDuration);
+
+  //-------------------------------------------------------------
+  //
+  //   set some main parameters for background model learning.
+  //   in general, we can set large updating rates for background
+  //   model learning and set small updating rates in foreground
+  //   detection
+  void SetParameters(int max_lbp_mode_num,		// maximal LBP mode number
+    float mode_updating_learn_rate_per_second,	// background mode updating learning rate per second
+    float weight_updating_learn_rate_per_second,	// mode's weight updating learning rate per second
+    float low_init_mode_weight);			// the low initial mode weight
+
+  //-------------------------------------------------------------
+  //   PROVIDE A POINTER TO THE INPUT IMAGE
+  //   -> INDICATE WHERE THE NEW IMAGE TO PROCESS IS STORED
+  //
+  //   Here assumes that the input image will contain RGB images.
+  //   The memory of this image is handled by the caller.
+  //
+  //    The return value indicate whether the actual Background
+  //    Subtraction algorithm handles RGB images (1) or not (0).
+  //
+  int   SetRGBInputImage(IplImage  *  inputImage, CvRect *roi = NULL);
+
+  //-------------------------------------------------------------
+  //   PROVIDE A POINTER TO THE RESULT IMAGE
+  //   INDICATE WHERE THE BACKGROUND RESULT NEED TO BE STORED
+  //
+  int SetForegroundMaskImage(IplImage* fg_mask_img);
+  int SetForegroundProbImage(IplImage* fg_prob_img);
+
+  //-------------------------------------------------------------
+  // This function should be called each time a new image is
+  // available in the input image.
+  //
+  // The return value is 0 if everything goes well, a non-zero value
+  // otherwise.
+  //
+  int   Process();
+
+  //-------------------------------------------------------------
+  // this function should save parameters and information of the model
+  // (e.g. after a training of the model, or in such a way
+  // that the model can be reload to process the next frame
+  // type of save:
+  //	0 - background model information (pixel by pixel)
+  //	1 - background model parameters
+  //	2 - both background information (pixel by pixel) and parameters
+  void   Save(const char   *bg_model_fn, int save_type);
+  void   Save(const char* bg_model_fn);
+
+  //-------------------------------------------------------------
+  // this function should load the parameters necessary
+  // for the processing of the background subtraction or
+  // load background model information
+  bool   Load(const char  *bg_model_fn);
+
+
+  void SetCurrentFrameNumber(unsigned long cur_frame_no);
+
+  void GetForegroundMaskImage(IplImage *fg_mask_img);
+  void GetForegroundImage(IplImage *fg_img, CvScalar bg_color = CV_RGB(0, 255, 0));
+  void GetBackgroundImage(IplImage *bk_img);
+  void GetForegroundProbabilityImage(IplImage* fg_prob_img);
+
+  void GetBgLayerNoImage(IplImage *bg_layer_no_img, CvScalar* layer_colors = NULL, int layer_num = 0);
+  void GetLayeredBackgroundImage(int layered_no, IplImage *layered_bg_img, CvScalar empty_color = CV_RGB(0, 0, 0));
+  void GetCurrentLayeredBackgroundImage(int layered_no, IplImage *layered_bg_img, IplImage *layered_fg_img = NULL,
+    CvScalar layered_bg_bk_color = CV_RGB(0, 0, 0), CvScalar layered_fg_color = CV_RGB(255, 0, 0),
+    int smooth_win = 13, float smooth_sigma = 3.0f, float below_layer_noise = 0.5f, float above_layer_noise = 0.3f, int min_blob_size = 50);
+  float DistLBP(LBPStruct *LBP1, LBPStruct *LBP2);
+  void GetColoredBgMultiLayeredImage(IplImage *bg_multi_layer_img, CvScalar *layer_colors);
+  void UpdatePatternColorDistWeights(float *cur_pattern, float *bg_pattern);
+  void ExportLogMessage(char* msg);
+  void Postprocessing();
+  void GetFloatEdgeImage(IplImage *src, IplImage *dst);
+  void RemoveBackgroundLayers(PixelLBPStruct *PLBP, bool *removed_modes = NULL);
+  float CalColorRangeDist(unsigned char *cur_intensity, float *bg_intensity, float *max_intensity,
+    float *min_intensity, float shadow_rate, float highlight_rate);
+  float CalVectorsAngle(float *c1, unsigned char *c2, int length);
+  float CalVectorsNoisedAngle(float *bg_color, unsigned char *noised_color, float offset, int length);
+  void ComputeGradientImage(IplImage *src, IplImage *dst, bool bIsFloat);
+  float CalColorBgDist(uchar *cur_intensity, float *bg_intensity, float *max_intensity, float *min_intensity);
+  float CalPatternBgDist(float *cur_pattern, float *bg_pattern);
+
+  void GetForegroundMaskMap(CvMat *fg_mask_mat);
+  void Initialization(IplImage *first_img, int lbp_level_num, float *radiuses, int *neig_pt_nums);
+  void GetCurrentBackgroundDistMap(CvMat *bk_dist_map);
+  void BackgroundSubtractionProcess();
+  void SetBkMaskImage(IplImage *mask_img);
+  void SetNewImage(IplImage *new_img, CvRect *roi = NULL);
+
+  void ResetAllParameters();
+  void QuickSort(float *pData, unsigned short *pIdxes, long low, long high, bool bAscent);
+  void UpdateBgPixelPattern(float *cur_pattern, float *bg_bg_pattern);
+  void UpdateBgPixelColor(unsigned char* cur_intensity, float* bg_intensity);
+  void Update_MAX_MIN_Intensity(unsigned char *cur_intensity, float *max_intensity, float *min_intensity);
+  void MergeImages(int num, ...);
+
+  int	m_nChannel;				/* most of opencv functions support 1,2,3 or 4 channels, for the input images */
+
+  PixelLBPStruct*	m_pPixelLBPs;			/* the LBP texture patterns for each image */
+  int	m_nMaxLBPModeNum;			/* the maximal number for the used LBP pattern models */
+  float	m_fModeUpdatingLearnRate;		/* the background mode learning rate */
+  float	m_fWeightUpdatingLearnRate;		/* the background mode weight updating rate */
+  float	m_f1_ModeUpdatingLearnRate;		/* 1 - background_mode_learning_rate */
+  float	m_f1_WeightUpdatingLearnRate;		/* 1 - background_mode_weight_updating_rate */
+  float	m_fRobustColorOffset;			/* the intensity offset robust to noise */
+  float	m_fLowInitialModeWeight;		/* the lowest weight of initial background mode */
+  int	m_nLBPLength;				/* the length of texture LBP operator */
+  float	m_fPatternColorDistBgThreshold;		/* the threshold value used to classify background and foreground */
+  float	m_fPatternColorDistBgUpdatedThreshold;	/* the threshold value used to update the background modeling */
+  float	m_fMinBgLayerWeight;			/* the minimal weight to remove background layers */
+
+  int	m_nPatternDistSmoothNeigHalfSize;	/* the neighboring half size of gaussian window to remove the noise
+                                        on the distance map */
+  float	m_fPatternDistConvGaussianSigma;	/* the gaussian sigma used to remove the noise on the distance map */
+
+  float	m_fBackgroundModelPercent;		/* the background mode percent, the first several background modes
+                                      with high mode weights should be regarded as reliable background modes */
+
+  float	m_fRobustShadowRate;			/* the minimal shadow rate, [0.4, 0.7] */
+  float	m_fRobustHighlightRate;			/* the maximal highlight rate, [1.1, 1.4] */
+
+  int	m_nLBPImgNum;				/* the number of images used for texture LBP feature */
+
+  float	m_fMinLBPBinaryProb;			/* the minimal LBP binary probability */
+  float	m_f1_MinLBPBinaryProb;			/* 1 - minimal_LBP_binary_probability */
+
+  CvSize	m_cvImgSize;				/* the image size (width, height) */
+
+  unsigned long	m_nCurImgFrameIdx;			/* the frame index of current image */
+
+  bool	m_bUsedGradImage;			/* the boolean variable signaling whether the gradient image is used
+                              or not for computing LBP operator */
+
+  bool	m_bUsedColorLBP;			/* true - multi-channel color image for LBP operator,
+                              false - gray-scale image for LBP operator  */
+
+  CLocalBinaryPattern	m_cLBP;			/* the class instant for computing LBP (local binary pattern) texture feature */
+
+  IplImage* m_pBkMaskImg;				/* the mask image corresponding to the input image,
+                                i.e. all the masked pixels should be processed  */
+
+  IplImage* m_pOrgImg;				/* the original image */
+  IplImage** m_ppOrgLBPImgs;			/* the multi-layer images used for LBP feature extraction */
+  IplImage* m_pFgImg;				/* the foreground image */
+  IplImage* m_pBgImg;				/* the background image */
+  IplImage* m_pFgMaskImg;				/* the foreground mask image */
+  IplImage* m_pBgDistImg;				/* the background distance image (float) */
+  IplImage* m_pEdgeImg;				/* the edge image used for cross bilateral filter */
+  IplImage* m_pFgProbImg;				/* the foreground probability image (uchar) */
+
+  IplImage* m_pFirstAppearingTimeMap;
+
+#ifdef LINUX_BILATERAL_FILTER
+  CCrossBilateralFilter	m_cCrossBF;		/* the class instant for cross bilateral filter
+                                      which should be used to remove noise on the distance map */
+#endif
+
+  bool	m_disableLearning;
+  float	m_fSigmaS;				/* sigma in the spatial domain for cross bilateral filter */
+  float	m_fSigmaR;				/* sigma in the normalized intensity domain for cross bilateral filter */
+
+  float	m_fTextureWeight;			/* the weight value of texture LBP feature
+                              for background modeling & foreground detection */
+
+  float	m_fColorWeight;				/* the weight value of color invariant feature
+                              for background modeling & foreground detection */
+
+  float	m_fWeightUpdatingConstant;		/* the constant ( >= 1 ) for 'hysteries' weight updating scheme
+                                      (increase when matched, decrease when un-matched */
+
+  float	m_fReliableBackgroundModeWeight;	/* the weight value for background mode
+                                          which should be regarded as a reliable background mode,
+                                          which is useful for multi-layer scheme */
+
+  float	m_fMinNoisedAngle;			/* the minimal angle value between the background color
+                                and the noised observed color */
+
+  float	m_fMinNoisedAngleSine;			/* the minimal angle sine value between the background color
+                                    and the noised observed color */
+
+  float	m_fFrameDuration;			/* frame duration */
+
+  float	m_fModeUpdatingLearnRatePerSecond;
+  float	m_fWeightUpdatingLearnRatePerSecond;
+
+  int m_nLBPLevelNum;
+  float m_pLBPRadiuses[10];
+  int m_pLBPMeigPointNums[10];
+
+  CvRect* m_pROI;
+  CMultiLayerBGS();
+  virtual ~CMultiLayerBGS();
+};
+
+#endif // !defined(_MULTI_LAYER_BGS_H_)
+

--- a/package_bgs/jmo/LocalBinaryPattern.cpp
+++ b/package_bgs/jmo/LocalBinaryPattern.cpp
@@ -1,0 +1,310 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// LocalBinaryPattern.cpp: implementation of the CLocalBinaryPattern class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "LocalBinaryPattern.h"
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+CLocalBinaryPattern::CLocalBinaryPattern()
+{
+  m_ppOrgImgs = NULL;
+  m_pRadiuses = NULL;
+  m_fRobustWhiteNoise = 3.0f;
+  m_pNeigPointsNums = NULL;
+  m_pXYShifts = NULL;
+  m_pShiftedImg = NULL;
+}
+
+CLocalBinaryPattern::~CLocalBinaryPattern()
+{
+  FreeMemories();
+}
+
+void CLocalBinaryPattern::Initialization(IplImage **first_imgs, int imgs_num, int level_num, float *radius, int *neig_pt_num, float robust_white_noise, int type)
+{
+
+  m_nImgsNum = imgs_num;
+
+  m_nLBPLevelNum = level_num;
+
+  m_pRadiuses = new float[m_nLBPLevelNum];
+  m_pNeigPointsNums = new int[m_nLBPLevelNum];
+  m_ppOrgImgs = first_imgs;
+
+  int a, b;
+  for (a = 0; a < m_nImgsNum; a++) {
+    m_cvImgSize = cvGetSize(first_imgs[a]);
+
+    if (first_imgs[a]->nChannels > 1) {
+      printf("Input image channel must be 1!");
+      exit(1);
+    }
+  }
+
+  int tot_neig_pts_num = 0;
+  for (a = 0; a < m_nLBPLevelNum; a++) {
+    m_pRadiuses[a] = radius[a];
+    m_pNeigPointsNums[a] = neig_pt_num[a];
+    tot_neig_pts_num += neig_pt_num[a];
+    if (m_pNeigPointsNums[a] % 2 != 0) {
+      printf("Even number must be given for points number for LBP!\n");
+      exit(1);
+    }
+  }
+
+  m_pShiftedImg = cvCloneImage(m_ppOrgImgs[0]);
+
+  m_pXYShifts = new CvPoint[tot_neig_pts_num];
+
+  m_nMaxShift.x = 0;
+  m_nMaxShift.y = 0;
+  int shift_idx = 0;
+  for (a = 0; a < m_nLBPLevelNum; a++)
+  for (b = 0; b < m_pNeigPointsNums[a]; b++) {
+    // compute the offset of neig point
+    CalNeigPixelOffset(m_pRadiuses[a], m_pNeigPointsNums[a], b, m_pXYShifts[shift_idx].x, m_pXYShifts[shift_idx].y);
+    m_nMaxShift.x = MAX(m_nMaxShift.x, m_pXYShifts[shift_idx].x);
+    m_nMaxShift.y = MAX(m_nMaxShift.y, m_pXYShifts[shift_idx].y);
+    shift_idx++;
+  }
+
+  m_fRobustWhiteNoise = robust_white_noise;
+}
+
+void CLocalBinaryPattern::SetNewImages(IplImage **new_imgs)
+{
+  m_ppOrgImgs = new_imgs;
+}
+
+void CLocalBinaryPattern::ComputeLBP(PixelLBPStruct *PLBP, CvRect *roi)
+{
+  float *dif_pattern;
+  float *_dif_pattern;
+  PixelLBPStruct *_PLBP;
+  int data_length;
+  float *cur_pattern;
+
+  // allocate memories
+  if (roi)
+    data_length = roi->height*roi->width;
+  else
+    data_length = m_cvImgSize.width*m_cvImgSize.height;
+
+  dif_pattern = new float[data_length];
+
+  int img_idx, pt_idx, yx, level;
+  int pattern_idx = 0;
+  for (img_idx = 0; img_idx < m_nImgsNum; img_idx++) {
+    for (level = 0; level < m_nLBPLevelNum; level++) {
+      for (pt_idx = 0; pt_idx < m_pNeigPointsNums[level]; pt_idx++) {
+
+        // computing the shifted image
+        CalShiftedImage(m_ppOrgImgs[img_idx], m_pXYShifts[pattern_idx].x, m_pXYShifts[pattern_idx].y, m_pShiftedImg, roi);
+
+        // computing the different binary images
+        CalImageDifferenceMap(m_ppOrgImgs[img_idx], m_pShiftedImg, dif_pattern, roi);
+
+        // set the binary values
+        _PLBP = PLBP;
+        _dif_pattern = dif_pattern;
+
+        if (roi) {
+          int x, y;
+          for (y = 0; y < roi->height; y++)  {
+            _PLBP = PLBP + (y + roi->y)*m_cvImgSize.width + roi->x;
+            for (x = 0; x < roi->width; x++) {
+              cur_pattern = (*_PLBP++).cur_pattern;
+              cur_pattern[pattern_idx] = *_dif_pattern++;
+            }
+          }
+        }
+        else {
+          for (yx = 0; yx < data_length; yx++) {
+            cur_pattern = (*_PLBP++).cur_pattern;
+            cur_pattern[pattern_idx] = *_dif_pattern++;
+          }
+        }
+
+        pattern_idx++;
+
+      }
+    }
+  }
+
+  // release memories
+  delete[] dif_pattern;
+
+  //delete [] shifted_dif_pattern;
+  //cvReleaseImage(&shifted_img);
+  //cvReleaseImage(&pattern_img);
+}
+
+void CLocalBinaryPattern::FreeMemories()
+{
+  delete[] m_pRadiuses;
+  delete[] m_pNeigPointsNums;
+  delete[] m_pXYShifts;
+  cvReleaseImage(&m_pShiftedImg);
+
+  m_pXYShifts = NULL;
+  m_pRadiuses = NULL;
+  m_pNeigPointsNums = NULL;
+  m_pShiftedImg = NULL;
+}
+
+void CLocalBinaryPattern::SetShiftedMeshGrid(CvSize img_size, float offset_x, float offset_y, CvMat *grid_map_x, CvMat *grid_map_y)
+{
+  float *gX = (float*)(grid_map_x->data.ptr);
+  float *gY = (float*)(grid_map_y->data.ptr);
+
+  int x, y;
+  for (y = 0; y < img_size.height; y++) {
+    for (x = 0; x < img_size.width; x++) {
+      *gX++ = (float)x + offset_x;
+      *gY++ = (float)y + offset_y;
+    }
+  }
+}
+
+void CLocalBinaryPattern::CalShiftedImage(IplImage *src, int offset_x, int offset_y, IplImage *dst, CvRect *roi)
+{
+  CvRect src_roi, dst_roi;
+  int roi_width, roi_height;
+
+  if (roi) {
+    src_roi.x = MAX(offset_x + roi->x, 0);
+    src_roi.y = MAX(offset_y + roi->y, 0);
+
+    dst_roi.x = MAX(-(offset_x + roi->x), roi->x);
+    dst_roi.y = MAX(-(offset_y + roi->y), roi->y);
+
+    roi_width = MIN(MIN(roi->width + (int)fabsf((float)offset_x), src->width - src_roi.x), dst->width - dst_roi.x);
+    roi_height = MIN(MIN(roi->height + (int)fabsf((float)offset_y), src->height - src_roi.y), dst->height - dst_roi.y);
+
+    src_roi.width = roi_width;
+    src_roi.height = roi_height;
+
+    dst_roi.width = roi_width;
+    dst_roi.height = roi_height;
+  }
+  else {
+    roi_width = src->width - (int)fabsf((float)offset_x);
+    roi_height = src->height - (int)fabsf((float)offset_y);
+
+    src_roi.x = MAX(offset_x, 0);
+    src_roi.y = MAX(offset_y, 0);
+    src_roi.width = roi_width;
+    src_roi.height = roi_height;
+
+    dst_roi.x = MAX(-offset_x, 0);
+    dst_roi.y = MAX(-offset_y, 0);
+    dst_roi.width = roi_width;
+    dst_roi.height = roi_height;
+  }
+
+  cvSet(dst, cvScalar(0));
+
+  if (roi_width <= 0 || roi_height <= 0)
+    return;
+
+  cvSetImageROI(src, src_roi);
+  cvSetImageROI(dst, dst_roi);
+  cvCopy(src, dst);
+  cvResetImageROI(src);
+  cvResetImageROI(dst);
+}
+
+void CLocalBinaryPattern::CalNeigPixelOffset(float radius, int tot_neig_pts_num, int neig_pt_idx, int &offset_x, int &offset_y)
+{
+  float angle = (float)neig_pt_idx / (float)tot_neig_pts_num*2.0f*PI;
+  offset_x = cvRound(radius*cosf(angle));
+  offset_y = cvRound(-radius*sinf(angle));
+}
+
+void CLocalBinaryPattern::CalImageDifferenceMap(IplImage *cent_img, IplImage *neig_img, float *pattern, CvRect *roi)
+{
+  COpencvDataConversion<uchar, uchar> ODC;
+
+  if (roi) {
+    cvSetImageROI(cent_img, *roi);
+    cvSetImageROI(neig_img, *roi);
+  }
+
+  uchar *_centI = ODC.GetImageData(cent_img);
+  uchar *_neigI = ODC.GetImageData(neig_img);
+  uchar *centI = _centI;
+  uchar *neigI = _neigI;
+
+  float *tmp_pattern = pattern;
+
+  int xy;
+  int length;
+
+  if (roi)
+    length = roi->height*roi->width;
+  else
+    length = cent_img->height*cent_img->width;
+
+  for (xy = 0; xy < length; xy++) {
+    *tmp_pattern = (float)BINARY_PATTERM_ELEM(*neigI, *centI, m_fRobustWhiteNoise);
+    tmp_pattern++;
+    centI++;
+    neigI++;
+  }
+
+  if (roi) {
+    cvResetImageROI(cent_img);
+    cvResetImageROI(neig_img);
+  }
+
+  // release memories
+  delete[] _centI;
+  delete[] _neigI;
+
+}
+

--- a/package_bgs/jmo/LocalBinaryPattern.h
+++ b/package_bgs/jmo/LocalBinaryPattern.h
@@ -1,0 +1,103 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// LocalBinaryPattern.h: interface for the CLocalBinaryPattern class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(_LOCAL_BINARY_PATTERN_H_)
+#define _LOCAL_BINARY_PATTERN_H_
+
+#include "OpenCvLegacyIncludes.h"
+#include "BGS.h"
+
+
+/************************************************************************/
+/* two types of computing the LBP operators but currently GENERAL_LBP   */
+/* has been implemented.                                                */
+/************************************************************************/
+#define	GENERAL_LBP	0
+#define SYMMETRIC_LBP	1
+
+#include <cstdio>						// C I/O (for sscanf)
+#include "OpenCvDataConversion.h"
+
+
+class CLocalBinaryPattern
+{
+public:
+  void CalImageDifferenceMap(IplImage *cent_img, IplImage *neig_img, float *pattern, CvRect *roi = NULL);
+  void CalNeigPixelOffset(float radius, int tot_neig_pts_num, int neig_pt_idx, int &offset_x, int &offset_y);
+  void CalShiftedImage(IplImage *src, int offset_x, int offset_y, IplImage *dst, CvRect *roi = NULL);
+  void FreeMemories();
+  void ComputeLBP(PixelLBPStruct *PLBP, CvRect *roi = NULL);
+  void SetNewImages(IplImage **new_imgs);
+
+  IplImage** m_ppOrgImgs;			/* the original images used for computing the LBP operators */
+
+  void Initialization(IplImage **first_imgs, int imgs_num,
+    int level_num, float *radius, int *neig_pt_num,
+    float robust_white_noise = 3.0f, int type = GENERAL_LBP);
+
+  CLocalBinaryPattern();
+  virtual ~CLocalBinaryPattern();
+
+  float	m_fRobustWhiteNoise;		/* the robust noise value for computing the LBP operator in each channel */
+
+private:
+  void SetShiftedMeshGrid(CvSize img_size, float offset_x, float offset_y, CvMat *grid_map_x, CvMat *grid_map_y);
+
+  float*	m_pRadiuses;			/* the circle radiuses for the LBP operator */
+  int	m_nLBPType;			/* the type of computing LBP operator */
+  int*	m_pNeigPointsNums;		/* the numbers of neighboring pixels on multi-level circles */
+  int	m_nImgsNum;			/* the number of multi-channel image */
+  int	m_nLBPLevelNum;			/* the number of multi-level LBP operator */
+  CvSize	m_cvImgSize;			/* the image size (width, height) */
+
+  CvPoint* m_pXYShifts;
+  CvPoint	m_nMaxShift;
+
+  IplImage* m_pShiftedImg;
+};
+
+#endif // !defined(_LOCAL_BINARY_PATTERN_H_)
+

--- a/package_bgs/jmo/MultiLayerBGS.cpp
+++ b/package_bgs/jmo/MultiLayerBGS.cpp
@@ -1,0 +1,331 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "MultiLayerBGS.h"
+
+MultiLayerBGS::MultiLayerBGS() : firstTime(true), frameNumber(0), showOutput(true), 
+saveModel(false), disableDetectMode(true), disableLearning(false), detectAfter(0), bg_model_preload(""), loadDefaultParams(true)
+{
+  std::cout << "MultiLayerBGS()" << std::endl;
+}
+
+MultiLayerBGS::~MultiLayerBGS()
+{
+  finish();
+  std::cout << "~MultiLayerBGS()" << std::endl;
+}
+
+void MultiLayerBGS::setStatus(Status _status)
+{
+  status = _status;
+}
+
+void MultiLayerBGS::finish(void)
+{
+  if (bg_model_preload.empty())
+  {
+    bg_model_preload = "./models/MultiLayerBGSModel.yml";
+    saveConfig();
+  }
+
+  if (status == MLBGS_LEARN && saveModel == true)
+  {
+    std::cout << "MultiLayerBGS saving background model: " << bg_model_preload << std::endl;
+    BGS->Save(bg_model_preload.c_str());
+  }
+
+  cvReleaseImage(&fg_img);
+  cvReleaseImage(&bg_img);
+  cvReleaseImage(&fg_prob_img);
+  cvReleaseImage(&fg_mask_img);
+  cvReleaseImage(&fg_prob_img3);
+  cvReleaseImage(&merged_img);
+
+  delete BGS;
+}
+
+void MultiLayerBGS::process(const cv::Mat &img_input, cv::Mat &img_output, cv::Mat &img_bgmodel)
+{
+  if (img_input.empty())
+    return;
+
+  loadConfig();
+
+  CvSize img_size = cvSize(cvCeil((double)img_input.size().width), cvCeil((double)img_input.size().height));
+
+  if (firstTime)
+  {
+    if (disableDetectMode)
+      status = MLBGS_LEARN;
+
+    if (status == MLBGS_LEARN)
+      std::cout << "MultiLayerBGS in LEARN mode" << std::endl;
+
+    if (status == MLBGS_DETECT)
+      std::cout << "MultiLayerBGS in DETECT mode" << std::endl;
+
+    org_img = new IplImage(img_input);
+
+    fg_img = cvCreateImage(img_size, org_img->depth, org_img->nChannels);
+    bg_img = cvCreateImage(img_size, org_img->depth, org_img->nChannels);
+    fg_prob_img = cvCreateImage(img_size, org_img->depth, 1);
+    fg_mask_img = cvCreateImage(img_size, org_img->depth, 1);
+    fg_prob_img3 = cvCreateImage(img_size, org_img->depth, org_img->nChannels);
+    merged_img = cvCreateImage(cvSize(img_size.width * 2, img_size.height * 2), org_img->depth, org_img->nChannels);
+
+    BGS = new CMultiLayerBGS();
+    BGS->Init(img_size.width, img_size.height);
+    BGS->SetForegroundMaskImage(fg_mask_img);
+    BGS->SetForegroundProbImage(fg_prob_img);
+
+    if (bg_model_preload.empty() == false)
+    {
+      std::cout << "MultiLayerBGS loading background model: " << bg_model_preload << std::endl;
+      BGS->Load(bg_model_preload.c_str());
+    }
+
+    if (status == MLBGS_DETECT)
+    {
+      BGS->m_disableLearning = disableLearning;
+
+      if (disableLearning)
+        std::cout << "MultiLayerBGS disabled learning in DETECT mode" << std::endl;
+      else
+        std::cout << "MultiLayerBGS enabled learning in DETECT mode" << std::endl;
+    }
+
+    if (loadDefaultParams)
+    {
+      std::cout << "MultiLayerBGS loading default params" << std::endl;
+
+      max_mode_num = 5;
+      weight_updating_constant = 5.0;
+      texture_weight = 0.5;
+      bg_mode_percent = 0.6f;
+      pattern_neig_half_size = 4;
+      pattern_neig_gaus_sigma = 3.0f;
+      bg_prob_threshold = 0.2f;
+      bg_prob_updating_threshold = 0.2f;
+      robust_LBP_constant = 3;
+      min_noised_angle = 10.0 / 180.0 * PI; //0,01768
+      shadow_rate = 0.6f;
+      highlight_rate = 1.2f;
+      bilater_filter_sigma_s = 3.0f;
+      bilater_filter_sigma_r = 0.1f;
+    }
+    else
+      std::cout << "MultiLayerBGS loading config params" << std::endl;
+
+    BGS->m_nMaxLBPModeNum = max_mode_num;
+    BGS->m_fWeightUpdatingConstant = weight_updating_constant;
+    BGS->m_fTextureWeight = texture_weight;
+    BGS->m_fBackgroundModelPercent = bg_mode_percent;
+    BGS->m_nPatternDistSmoothNeigHalfSize = pattern_neig_half_size;
+    BGS->m_fPatternDistConvGaussianSigma = pattern_neig_gaus_sigma;
+    BGS->m_fPatternColorDistBgThreshold = bg_prob_threshold;
+    BGS->m_fPatternColorDistBgUpdatedThreshold = bg_prob_updating_threshold;
+    BGS->m_fRobustColorOffset = robust_LBP_constant;
+    BGS->m_fMinNoisedAngle = min_noised_angle;
+    BGS->m_fRobustShadowRate = shadow_rate;
+    BGS->m_fRobustHighlightRate = highlight_rate;
+    BGS->m_fSigmaS = bilater_filter_sigma_s;
+    BGS->m_fSigmaR = bilater_filter_sigma_r;
+
+    if (loadDefaultParams)
+    {
+      //frame_duration = 1.0 / 30.0;
+      //frame_duration = 1.0 / 25.0;
+      frame_duration = 1.0f / 10.0f;
+    }
+
+    BGS->SetFrameRate(frame_duration);
+
+    if (status == MLBGS_LEARN)
+    {
+      if (loadDefaultParams)
+      {
+        mode_learn_rate_per_second = 0.5;
+        weight_learn_rate_per_second = 0.5;
+        init_mode_weight = 0.05f;
+      }
+      else
+      {
+        mode_learn_rate_per_second = learn_mode_learn_rate_per_second;
+        weight_learn_rate_per_second = learn_weight_learn_rate_per_second;
+        init_mode_weight = learn_init_mode_weight;
+      }
+    }
+
+    if (status == MLBGS_DETECT)
+    {
+      if (loadDefaultParams)
+      {
+        mode_learn_rate_per_second = 0.01f;
+        weight_learn_rate_per_second = 0.01f;
+        init_mode_weight = 0.001f;
+      }
+      else
+      {
+        mode_learn_rate_per_second = detect_mode_learn_rate_per_second;
+        weight_learn_rate_per_second = detect_weight_learn_rate_per_second;
+        init_mode_weight = detect_init_mode_weight;
+      }
+    }
+
+    BGS->SetParameters(max_mode_num, mode_learn_rate_per_second, weight_learn_rate_per_second, init_mode_weight);
+
+    saveConfig();
+
+    delete org_img;
+  }
+
+  //IplImage* inputImage = new IplImage(img_input);
+  //IplImage* img = cvCreateImage(img_size, IPL_DEPTH_8U, 3);
+  //cvCopy(inputImage, img);
+  //delete inputImage;
+
+  if (detectAfter > 0 && detectAfter == frameNumber)
+  {
+    std::cout << "MultiLayerBGS in DETECT mode" << std::endl;
+
+    status = MLBGS_DETECT;
+
+    mode_learn_rate_per_second = 0.01f;
+    weight_learn_rate_per_second = 0.01f;
+    init_mode_weight = 0.001f;
+
+    BGS->SetParameters(max_mode_num, mode_learn_rate_per_second, weight_learn_rate_per_second, init_mode_weight);
+
+    BGS->m_disableLearning = disableLearning;
+
+    if (disableLearning)
+      std::cout << "MultiLayerBGS disabled learning in DETECT mode" << std::endl;
+    else
+      std::cout << "MultiLayerBGS enabled learning in DETECT mode" << std::endl;
+  }
+
+  IplImage* img = new IplImage(img_input);
+
+  BGS->SetRGBInputImage(img);
+  BGS->Process();
+
+  BGS->GetBackgroundImage(bg_img);
+  BGS->GetForegroundImage(fg_img);
+  BGS->GetForegroundProbabilityImage(fg_prob_img3);
+  BGS->GetForegroundMaskImage(fg_mask_img);
+  BGS->MergeImages(4, img, bg_img, fg_prob_img3, fg_img, merged_img);
+
+  img_merged = cv::cvarrToMat(merged_img);
+  img_foreground = cv::cvarrToMat(fg_mask_img);
+  img_background = cv::cvarrToMat(bg_img);
+
+  if (showOutput)
+  {
+    cv::imshow("MLBGS Layers", img_merged);
+    cv::imshow("MLBGS FG Mask", img_foreground);
+  }
+
+  img_foreground.copyTo(img_output);
+  img_background.copyTo(img_bgmodel);
+
+  delete img;
+  //cvReleaseImage(&img);
+
+  firstTime = false;
+  frameNumber++;
+}
+
+void MultiLayerBGS::saveConfig()
+{
+  CvFileStorage* fs = cvOpenFileStorage("./config/MultiLayerBGS.xml", 0, CV_STORAGE_WRITE);
+
+  cvWriteString(fs, "preloadModel", bg_model_preload.c_str());
+  cvWriteInt(fs, "saveModel", saveModel);
+  cvWriteInt(fs, "detectAfter", detectAfter);
+  cvWriteInt(fs, "disableDetectMode", disableDetectMode);
+  cvWriteInt(fs, "disableLearningInDetecMode", disableLearning);
+  cvWriteInt(fs, "loadDefaultParams", loadDefaultParams);
+
+  cvWriteInt(fs, "max_mode_num", max_mode_num);
+  cvWriteReal(fs, "weight_updating_constant", weight_updating_constant);
+  cvWriteReal(fs, "texture_weight", texture_weight);
+  cvWriteReal(fs, "bg_mode_percent", bg_mode_percent);
+  cvWriteInt(fs, "pattern_neig_half_size", pattern_neig_half_size);
+  cvWriteReal(fs, "pattern_neig_gaus_sigma", pattern_neig_gaus_sigma);
+  cvWriteReal(fs, "bg_prob_threshold", bg_prob_threshold);
+  cvWriteReal(fs, "bg_prob_updating_threshold", bg_prob_updating_threshold);
+  cvWriteInt(fs, "robust_LBP_constant", robust_LBP_constant);
+  cvWriteReal(fs, "min_noised_angle", min_noised_angle);
+  cvWriteReal(fs, "shadow_rate", shadow_rate);
+  cvWriteReal(fs, "highlight_rate", highlight_rate);
+  cvWriteReal(fs, "bilater_filter_sigma_s", bilater_filter_sigma_s);
+  cvWriteReal(fs, "bilater_filter_sigma_r", bilater_filter_sigma_r);
+
+  cvWriteReal(fs, "frame_duration", frame_duration);
+
+  cvWriteReal(fs, "learn_mode_learn_rate_per_second", learn_mode_learn_rate_per_second);
+  cvWriteReal(fs, "learn_weight_learn_rate_per_second", learn_weight_learn_rate_per_second);
+  cvWriteReal(fs, "learn_init_mode_weight", learn_init_mode_weight);
+
+  cvWriteReal(fs, "detect_mode_learn_rate_per_second", detect_mode_learn_rate_per_second);
+  cvWriteReal(fs, "detect_weight_learn_rate_per_second", detect_weight_learn_rate_per_second);
+  cvWriteReal(fs, "detect_init_mode_weight", detect_init_mode_weight);
+
+  cvWriteInt(fs, "showOutput", showOutput);
+
+  cvReleaseFileStorage(&fs);
+}
+
+void MultiLayerBGS::loadConfig()
+{
+  CvFileStorage* fs = cvOpenFileStorage("./config/MultiLayerBGS.xml", 0, CV_STORAGE_READ);
+
+  bg_model_preload = cvReadStringByName(fs, 0, "preloadModel", "");
+  saveModel = cvReadIntByName(fs, 0, "saveModel", false);
+  detectAfter = cvReadIntByName(fs, 0, "detectAfter", 0);
+  disableDetectMode = cvReadIntByName(fs, 0, "disableDetectMode", true);
+  disableLearning = cvReadIntByName(fs, 0, "disableLearningInDetecMode", false);
+  loadDefaultParams = cvReadIntByName(fs, 0, "loadDefaultParams", true);
+
+  max_mode_num = cvReadIntByName(fs, 0, "max_mode_num", 5);
+  weight_updating_constant = cvReadRealByName(fs, 0, "weight_updating_constant", 5.0);
+  texture_weight = cvReadRealByName(fs, 0, "texture_weight", 0.5);
+  bg_mode_percent = cvReadRealByName(fs, 0, "bg_mode_percent", 0.6);
+  pattern_neig_half_size = cvReadIntByName(fs, 0, "pattern_neig_half_size", 4);
+  pattern_neig_gaus_sigma = cvReadRealByName(fs, 0, "pattern_neig_gaus_sigma", 3.0);
+  bg_prob_threshold = cvReadRealByName(fs, 0, "bg_prob_threshold", 0.2);
+  bg_prob_updating_threshold = cvReadRealByName(fs, 0, "bg_prob_updating_threshold", 0.2);
+  robust_LBP_constant = cvReadIntByName(fs, 0, "robust_LBP_constant", 3);
+  min_noised_angle = cvReadRealByName(fs, 0, "min_noised_angle", 0.01768);
+  shadow_rate = cvReadRealByName(fs, 0, "shadow_rate", 0.6);
+  highlight_rate = cvReadRealByName(fs, 0, "highlight_rate", 1.2);
+  bilater_filter_sigma_s = cvReadRealByName(fs, 0, "bilater_filter_sigma_s", 3.0);
+  bilater_filter_sigma_r = cvReadRealByName(fs, 0, "bilater_filter_sigma_r", 0.1);
+
+  frame_duration = cvReadRealByName(fs, 0, "frame_duration", 0.1);
+
+  learn_mode_learn_rate_per_second = cvReadRealByName(fs, 0, "learn_mode_learn_rate_per_second", 0.5);
+  learn_weight_learn_rate_per_second = cvReadRealByName(fs, 0, "learn_weight_learn_rate_per_second", 0.5);
+  learn_init_mode_weight = cvReadRealByName(fs, 0, "learn_init_mode_weight", 0.05);
+
+  detect_mode_learn_rate_per_second = cvReadRealByName(fs, 0, "detect_mode_learn_rate_per_second", 0.01);
+  detect_weight_learn_rate_per_second = cvReadRealByName(fs, 0, "detect_weight_learn_rate_per_second", 0.01);
+  detect_init_mode_weight = cvReadRealByName(fs, 0, "detect_init_mode_weight", 0.001);
+
+  showOutput = cvReadIntByName(fs, 0, "showOutput", true);
+
+  cvReleaseFileStorage(&fs);
+}

--- a/package_bgs/jmo/MultiLayerBGS.h
+++ b/package_bgs/jmo/MultiLayerBGS.h
@@ -1,0 +1,101 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <iostream>
+#include "OpenCvLegacyIncludes.h"
+
+
+#include "../IBGS.h"
+#include "CMultiLayerBGS.h"
+
+class MultiLayerBGS : public IBGS
+{
+public:
+  enum Status
+  {
+    MLBGS_NONE = -1,
+    MLBGS_LEARN = 0,
+    MLBGS_DETECT = 1
+  };
+
+private:
+  bool firstTime;
+  long long frameNumber;
+  cv::Mat img_foreground;
+  cv::Mat img_merged;
+  cv::Mat img_background;
+  bool showOutput;
+  bool saveModel;
+  bool disableDetectMode;
+  bool disableLearning;
+  int detectAfter;
+  CMultiLayerBGS* BGS;
+  Status status;
+  IplImage* img;
+  IplImage* org_img;
+  IplImage* fg_img;
+  IplImage* bg_img;
+  IplImage* fg_prob_img;
+  IplImage* fg_mask_img;
+  IplImage* fg_prob_img3;
+  IplImage* merged_img;
+  std::string bg_model_preload;
+
+  bool loadDefaultParams;
+
+  int max_mode_num;
+  float weight_updating_constant;
+  float texture_weight;
+  float bg_mode_percent;
+  int pattern_neig_half_size;
+  float pattern_neig_gaus_sigma;
+  float bg_prob_threshold;
+  float bg_prob_updating_threshold;
+  int robust_LBP_constant;
+  float min_noised_angle;
+  float shadow_rate;
+  float highlight_rate;
+  float bilater_filter_sigma_s;
+  float bilater_filter_sigma_r;
+
+  float frame_duration;
+
+  float mode_learn_rate_per_second;
+  float weight_learn_rate_per_second;
+  float init_mode_weight;
+
+  float learn_mode_learn_rate_per_second;
+  float learn_weight_learn_rate_per_second;
+  float learn_init_mode_weight;
+
+  float detect_mode_learn_rate_per_second;
+  float detect_weight_learn_rate_per_second;
+  float detect_init_mode_weight;
+
+public:
+  MultiLayerBGS();
+  ~MultiLayerBGS();
+
+  void setStatus(Status status);
+  void process(const cv::Mat &img_input, cv::Mat &img_output, cv::Mat &img_bgmodel);
+
+private:
+  void finish(void);
+  void saveConfig();
+  void loadConfig();
+};

--- a/package_bgs/jmo/OpenCvDataConversion.h
+++ b/package_bgs/jmo/OpenCvDataConversion.h
@@ -1,0 +1,224 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// OpencvDataConversion.h: interface for the COpencvDataConversion class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(_OPENCV_DATA_CONVERSION_H_)
+#define _OPENCV_DATA_CONVERSION_H_
+
+#include "OpenCvLegacyIncludes.h"
+#include <stdio.h>
+
+template <class TI, class TM>		/* class TI - the type of image data, class TM - the type of matrix data */
+class COpencvDataConversion
+{
+public:
+
+  /* get the image data */
+  TI * GetImageData(IplImage *img)
+  {
+    if (!img->roi) {	/* no ROI used, i.e. the whole image */
+      int y; //, x;
+      TI* img_data = new TI[img->width*img->height*img->nChannels];
+      TI* temp = img_data;
+      TI* x_data;
+
+      for (y = 0; y < img->height; y++) {
+        x_data = (TI*)(img->imageData + img->widthStep*y);
+        int row_length = img->width*img->nChannels;
+        memcpy(temp, x_data, sizeof(TI)*row_length);
+        temp += row_length;
+        /*
+        for ( x = 0 ; x < img->width*img->nChannels ; x++ )
+        *temp++ = *x_data++;
+        */
+      }
+
+      return img_data;
+    }
+    else {	/* get image data only in ROI */
+      int y;//, x;
+      TI* img_data = new TI[img->roi->width*img->roi->height*img->nChannels];
+      TI* temp = img_data;
+      TI* x_data;
+      for (y = img->roi->yOffset; y < img->roi->yOffset + img->roi->height; y++) {
+        x_data = (TI*)(img->imageData + img->widthStep*y + img->roi->xOffset*sizeof(TI)*img->nChannels);
+        int row_length = img->roi->width*img->nChannels;
+        memcpy(temp, x_data, sizeof(TI)*row_length);
+        temp += row_length;
+        /*
+        for ( x = 0 ; x < img->roi->width*img->nChannels ; x++ )
+        *temp++ = *x_data++;
+        */
+      }
+      return img_data;
+    }
+  };
+
+  /* set the image data */
+  void SetImageData(IplImage *img, TI *img_data)
+  {
+    if (!img->roi) {	/* no ROI used, i.e. the whole image */
+      int y;//, x;
+      TI* temp = img_data;
+      TI* x_data;
+      for (y = 0; y < img->height; y++) {
+        x_data = (TI*)(img->imageData + img->widthStep*y);
+        int row_length = img->width*img->nChannels;
+        memcpy(x_data, temp, sizeof(TI)*row_length);
+        temp += row_length;
+        /*
+        for ( x = 0 ; x < img->width*img->nChannels ; x++ )
+        *x_data++ = *temp++;
+        */
+      }
+    }
+    else {	/* set image data only in ROI */
+      int y;//, x;
+      TI* temp = img_data;
+      TI* x_data;
+      for (y = img->roi->yOffset; y < img->roi->yOffset + img->roi->height; y++) {
+        x_data = (TI*)(img->imageData + img->widthStep*y + img->roi->xOffset*sizeof(TI)*img->nChannels);
+        int row_length = img->roi->width*img->nChannels;
+        memcpy(x_data, temp, sizeof(TI)*row_length);
+        temp += row_length;
+        /*
+        for ( x = 0 ; x < img->roi->width*img->nChannels ; x++ )
+        *x_data++ = *temp++;
+        */
+      }
+    }
+  }
+
+  /* get the matrix data */
+  TM * GetMatData(CvMat *mat)
+  {
+    TM* mat_data = new TM[mat->width*mat->height];
+    memcpy(mat_data, mat->data.ptr, sizeof(TM)*mat->width*mat->height);
+    return mat_data;
+
+    /*
+    int y, x;
+    TM* mat_data = new TM[mat->width*mat->height];
+    TM* temp = mat_data;
+    TM* x_data;
+    for ( y = 0 ; y < mat->height ; y++ ) {
+    x_data = (TM*)(mat->data.ptr + mat->step*y);
+    for ( x = 0 ; x < mat->width ; x++ )
+    *temp++ = *x_data++;
+    }
+    return mat_data;
+    */
+  };
+
+  /* set the matrix data */
+  void SetMatData(CvMat *mat, TM *mat_data)
+  {
+    memcpy(mat->data.ptr, mat_data, sizeof(TM)*mat->width*mat->height);
+
+    /*
+    int y, x;
+    TM* temp = mat_data;
+    TM* x_data;
+    for ( y = 0 ; y < mat->height ; y++ ) {
+    x_data = (TM*)(mat->data.ptr + mat->step*y);
+    for ( x = 0 ; x < mat->width ; x++ )
+    *x_data++ = *temp++;
+    }
+    */
+  }
+
+  /* convert the image data to the matrix data */
+  void ConvertData(IplImage *img_src, CvMat *mat_dst)
+  {
+    if (img_src->nChannels > 1) {
+      printf("Must be one-channel image for ConvertImageData!\n");
+      exit(1);
+    }
+
+    TI* _img_data = GetImageData(img_src);
+    TM* _mat_data = new TM[img_src->width*img_src->height];
+
+    TI* img_data = _img_data;
+    TM* mat_data = _mat_data;
+    int i;
+    for (i = 0; i < img_src->width*img_src->height; i++)
+      *mat_data++ = (TM)(*img_data++);
+
+    SetMatData(mat_dst, _mat_data);
+
+    delete[] _img_data;
+    delete[] _mat_data;
+  }
+
+  /* convert the matrix data to the image data */
+  void ConvertData(CvMat *mat_src, IplImage *img_dst)
+  {
+    if (img_dst->nChannels > 1) {
+      printf("Must be one-channel image for ConvertImageData!\n");
+      exit(1);
+    }
+
+    TM* _mat_data = GetMatData(mat_src);
+    TI* _img_data = new TI[mat_src->width*mat_src->height];
+
+    TM* mat_data = _mat_data;
+    TI* img_data = _img_data;
+
+    int i;
+    for (i = 0; i < mat_src->width*mat_src->height; i++)
+      *img_data++ = (TI)(*mat_data++);
+
+    SetImageData(img_dst, _img_data);
+
+    delete[] _img_data;
+    delete[] _mat_data;
+  }
+
+  COpencvDataConversion() {};
+  virtual ~COpencvDataConversion() {};
+};
+
+#endif // !defined(_OPENCV_DATA_CONVERSION_H_)
+

--- a/package_bgs/jmo/OpenCvLegacyIncludes.h
+++ b/package_bgs/jmo/OpenCvLegacyIncludes.h
@@ -1,0 +1,54 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// OpenCvLegacyIncludes.h: necessary includes to compile with OpenCV 3.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(_OPENCV_LEGACY_INCLUDES_H_)
+#define _OPENCV_LEGACY_INCLUDES_H_
+
+#include "opencv2/core/core_c.h"
+#include "opencv2/core/types_c.h"
+#include "opencv2/imgproc/imgproc_c.h"
+
+#endif // !defined(_OPENCV_LEGACY_INCLUDES_H_)

--- a/package_bgs/jmo/blob.cpp
+++ b/package_bgs/jmo/blob.cpp
@@ -1,0 +1,1148 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************
+Blob.cpp
+
+- FUNCIONALITAT: Implementació de la classe CBlob
+- AUTOR: Inspecta S.L.
+MODIFICACIONS (Modificació, Autor, Data):
+
+
+FUNCTIONALITY: Implementation of the CBlob class and some helper classes to perform
+some calculations on it
+AUTHOR: Inspecta S.L.
+MODIFICATIONS (Modification, Author, Date):
+
+**************************************************************************/
+
+
+#include <limits.h>
+#include "blob.h"
+
+namespace Blob
+{
+
+  /**
+  - FUNCIÓ: CBlob
+  - FUNCIONALITAT: Constructor estàndard
+  - PARÀMETRES:
+  - RESULTAT:
+  - inicialització de totes les variables internes i de l'storage i la sequencia
+  per a les cantonades del blob
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlob
+  - FUNCTIONALITY: Standard constructor
+  - PARAMETERS:
+  - RESULT:
+  - memory allocation for the blob edges and initialization of member variables
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlob::CBlob()
+  {
+    etiqueta = -1;		// Flag indicates null region
+    exterior = 0;
+    area = 0.0f;
+    perimeter = 0.0f;
+    parent = -1;
+    minx = LONG_MAX;
+    maxx = 0;
+    miny = LONG_MAX;
+    maxy = 0;
+    sumx = 0;
+    sumy = 0;
+    sumxx = 0;
+    sumyy = 0;
+    sumxy = 0;
+    mean = 0;
+    stddev = 0;
+    externPerimeter = 0;
+
+    m_storage = cvCreateMemStorage(0);
+    edges = cvCreateSeq(CV_SEQ_KIND_GENERIC | CV_32SC2,
+      sizeof(CvContour),
+      sizeof(CvPoint), m_storage);
+  }
+
+  /**
+  - FUNCIÓ: CBlob
+  - FUNCIONALITAT: Constructor de còpia
+  - PARÀMETRES:
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlob
+  - FUNCTIONALITY: Copy constructor
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlob::CBlob(const CBlob &src)
+  {
+    // copiem les propietats del blob origen a l'actual
+    etiqueta = src.etiqueta;
+    exterior = src.exterior;
+    area = src.Area();
+    perimeter = src.Perimeter();
+    parent = src.parent;
+    minx = src.minx;
+    maxx = src.maxx;
+    miny = src.miny;
+    maxy = src.maxy;
+    sumx = src.sumx;
+    sumy = src.sumy;
+    sumxx = src.sumxx;
+    sumyy = src.sumyy;
+    sumxy = src.sumxy;
+    mean = src.mean;
+    stddev = src.stddev;
+    externPerimeter = src.externPerimeter;
+
+    // copiem els edges del blob origen a l'actual
+    CvSeqReader reader;
+    CvSeqWriter writer;
+    CvPoint edgeactual;
+
+    // creem una sequencia buida per als edges
+    m_storage = cvCreateMemStorage(0);
+    edges = cvCreateSeq(CV_SEQ_KIND_GENERIC | CV_32SC2,
+      sizeof(CvContour),
+      sizeof(CvPoint), m_storage);
+
+    cvStartReadSeq(src.Edges(), &reader);
+    cvStartAppendToSeq(edges, &writer);
+
+    for (int i = 0; i < src.Edges()->total; i++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      CV_WRITE_SEQ_ELEM(edgeactual, writer);
+    }
+
+    cvEndWriteSeq(&writer);
+  }
+  CBlob::CBlob(const CBlob *src)
+  {
+    // copiem les propietats del blob origen a l'actual
+    etiqueta = src->etiqueta;
+    exterior = src->exterior;
+    area = src->Area();
+    perimeter = src->Perimeter();
+    parent = src->parent;
+    minx = src->minx;
+    maxx = src->maxx;
+    miny = src->miny;
+    maxy = src->maxy;
+    sumx = src->sumx;
+    sumy = src->sumy;
+    sumxx = src->sumxx;
+    sumyy = src->sumyy;
+    sumxy = src->sumxy;
+    mean = src->mean;
+    stddev = src->stddev;
+    externPerimeter = src->externPerimeter;
+
+    // copiem els edges del blob origen a l'actual
+    CvSeqReader reader;
+    CvSeqWriter writer;
+    CvPoint edgeactual;
+
+    // creem una sequencia buida per als edges
+    m_storage = cvCreateMemStorage(0);
+    edges = cvCreateSeq(CV_SEQ_KIND_GENERIC | CV_32SC2,
+      sizeof(CvContour),
+      sizeof(CvPoint), m_storage);
+
+    cvStartReadSeq(src->Edges(), &reader);
+    cvStartAppendToSeq(edges, &writer);
+
+    for (int i = 0; i < src->Edges()->total; i++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      CV_WRITE_SEQ_ELEM(edgeactual, writer);
+    }
+
+    cvEndWriteSeq(&writer);
+  }
+
+  /**
+  - FUNCIÓ: ~CBlob
+  - FUNCIONALITAT: Destructor estàndard
+  - PARÀMETRES:
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlob
+  - FUNCTIONALITY: Standard destructor
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlob::~CBlob()
+  {
+    // Eliminar vèrtexs del blob 
+    cvClearSeq(edges);
+    // i la zona de memòria on són
+    cvReleaseMemStorage(&m_storage);
+  }
+
+  /**
+  - FUNCIÓ: operator=
+  - FUNCIONALITAT: Operador d'assignació
+  - PARÀMETRES:
+  - src: blob a assignar a l'actual
+  - RESULTAT:
+  - Substitueix el blob actual per el src
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: Assigment operator
+  - FUNCTIONALITY: Assigns a blob to the current
+  - PARAMETERS:
+  - src: blob to assign
+  - RESULT:
+  - the current blob is replaced by the src blob
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CBlob& CBlob::operator=(const CBlob &src)
+  {
+    // si ja són el mateix, no cal fer res
+    if (this != &src)
+    {
+      // Eliminar vèrtexs del blob 
+      cvClearSeq(edges);
+      // i la zona de memòria on són
+      cvReleaseMemStorage(&m_storage);
+
+      // creem una sequencia buida per als edges
+      m_storage = cvCreateMemStorage(0);
+      edges = cvCreateSeq(CV_SEQ_KIND_GENERIC | CV_32SC2,
+        sizeof(CvContour),
+        sizeof(CvPoint), m_storage);
+
+      // copiem les propietats del blob origen a l'actual
+      etiqueta = src.etiqueta;
+      exterior = src.exterior;
+      area = src.Area();
+      perimeter = src.Perimeter();
+      parent = src.parent;
+      minx = src.minx;
+      maxx = src.maxx;
+      miny = src.miny;
+      maxy = src.maxy;
+      sumx = src.sumx;
+      sumy = src.sumy;
+      sumxx = src.sumxx;
+      sumyy = src.sumyy;
+      sumxy = src.sumxy;
+      mean = src.mean;
+      stddev = src.stddev;
+      externPerimeter = src.externPerimeter;
+
+      // copiem els edges del blob origen a l'actual
+      CvSeqReader reader;
+      CvSeqWriter writer;
+      CvPoint edgeactual;
+
+      cvStartReadSeq(src.Edges(), &reader);
+      cvStartAppendToSeq(edges, &writer);
+
+      for (int i = 0; i < src.Edges()->total; i++)
+      {
+        CV_READ_SEQ_ELEM(edgeactual, reader);
+        CV_WRITE_SEQ_ELEM(edgeactual, writer);
+      }
+
+      cvEndWriteSeq(&writer);
+    }
+    return *this;
+  }
+
+  /**
+  - FUNCIÓ: FillBlob
+  - FUNCIONALITAT: Pinta l'interior d'un blob amb el color especificat
+  - PARÀMETRES:
+  - imatge: imatge on es vol pintar el el blob
+  - color: color amb que es vol pintar el blob
+  - RESULTAT:
+  - retorna la imatge d'entrada amb el blob pintat
+  - RESTRICCIONS:
+  - AUTOR:
+  - Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: FillBlob
+  - FUNCTIONALITY:
+  - Fills the blob with a specified colour
+  - PARAMETERS:
+  - imatge: where to paint
+  - color: colour to paint the blob
+  - RESULT:
+  - modifies input image and returns the seed point used to fill the blob
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlob::FillBlob(IplImage *imatge, CvScalar color, int offsetX /*=0*/, int offsetY /*=0*/) const
+  {
+
+    //verifiquem que existeixi el blob i que tingui cantonades
+    if (edges == NULL || edges->total == 0) return;
+
+    CvPoint edgeactual, pt1, pt2;
+    CvSeqReader reader;
+    vectorPunts vectorEdges = vectorPunts(edges->total);
+    vectorPunts::iterator itEdges, itEdgesSeguent;
+    bool dinsBlob;
+    int yActual;
+
+    // passem els punts del blob a un vector de punts de les STL
+    cvStartReadSeq(edges, &reader);
+    itEdges = vectorEdges.begin();
+    while (itEdges != vectorEdges.end())
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      *itEdges = edgeactual;
+      ++itEdges;
+    }
+    // ordenem el vector per les Y's i les X's d'esquerra a dreta
+    std::sort(vectorEdges.begin(), vectorEdges.end(), comparaCvPoint());
+
+    // recorrem el vector ordenat i fem linies entre punts consecutius
+    itEdges = vectorEdges.begin();
+    itEdgesSeguent = vectorEdges.begin() + 1;
+    dinsBlob = true;
+    while (itEdges != (vectorEdges.end() - 1))
+    {
+      yActual = (*itEdges).y;
+
+      if (((*itEdges).x != (*itEdgesSeguent).x) &&
+        ((*itEdgesSeguent).y == yActual)
+        )
+      {
+        if (dinsBlob)
+        {
+          pt1 = *itEdges;
+          pt1.x += offsetX;
+          pt1.y += offsetY;
+
+          pt2 = *itEdgesSeguent;
+          pt2.x += offsetX;
+          pt2.y += offsetY;
+
+          cvLine(imatge, pt1, pt2, color);
+        }
+        dinsBlob = !dinsBlob;
+      }
+      ++itEdges;
+      ++itEdgesSeguent;
+      if ((*itEdges).y != yActual) dinsBlob = true;
+    }
+    vectorEdges.clear();
+  }
+
+  /**
+  - FUNCIÓ: CopyEdges
+  - FUNCIONALITAT: Afegeix els vèrtexs del blob al blob destination
+  - PARÀMETRES:
+  - destination: blob al que volem afegir els vèrtexs
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CopyEdges
+  - FUNCTIONALITY: Adds the blob edges to destination
+  - PARAMETERS:
+  - destination: where to add the edges
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlob::CopyEdges(CBlob &destination) const
+  {
+    CvSeqReader reader;
+    CvSeqWriter writer;
+    CvPoint edgeactual;
+
+    cvStartReadSeq(edges, &reader);
+    cvStartAppendToSeq(destination.Edges(), &writer);
+
+    for (int i = 0; i < edges->total; i++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      CV_WRITE_SEQ_ELEM(edgeactual, writer);
+    }
+
+    cvEndWriteSeq(&writer);
+  }
+
+  /**
+  - FUNCIÓ: ClearEdges
+  - FUNCIONALITAT: Elimina els vèrtexs del blob
+  - PARÀMETRES:
+  - RESULTAT:
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: ClearEdges
+  - FUNCTIONALITY: Delete current blob edges
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  void CBlob::ClearEdges()
+  {
+    // Eliminar vèrtexs del blob eliminat
+    cvClearSeq(edges);
+  }
+
+  /**
+  - FUNCIÓ: GetConvexHull
+  - FUNCIONALITAT: Retorna el poligon convex del blob
+  - PARÀMETRES:
+  - dst: sequencia on desarem el resultat (no ha d'estar inicialitzada)
+  - RESULTAT:
+  - true si tot ha anat bé
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: GetConvexHull
+  - FUNCTIONALITY: Calculates the convex hull polygon of the blob
+  - PARAMETERS:
+  - dst: where to store the result
+  - RESULT:
+  - true if no error ocurred
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  bool CBlob::GetConvexHull(CvSeq **dst) const
+  {
+    if (edges != NULL && edges->total > 0)
+    {
+      *dst = cvConvexHull2(edges, 0, CV_CLOCKWISE, 0);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+  - FUNCIÓ: GetEllipse
+  - FUNCIONALITAT: Retorna l'ellipse que s'ajusta millor a les cantonades del blob
+  - PARÀMETRES:
+  - RESULTAT:
+  - estructura amb l'ellipse
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 25-05-2005.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: GetEllipse
+  - FUNCTIONALITY: Calculates the ellipse that best fits the edges of the blob
+  - PARAMETERS:
+  - RESULT:
+  - CvBox2D struct with the calculated ellipse
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  CvBox2D CBlob::GetEllipse() const
+  {
+    CvBox2D elipse;
+    // necessitem 6 punts per calcular l'elipse
+    if (edges != NULL && edges->total > 6)
+    {
+      elipse = cvFitEllipse2(edges);
+    }
+    else
+    {
+      elipse.center.x = 0.0;
+      elipse.center.y = 0.0;
+      elipse.size.width = 0.0;
+      elipse.size.height = 0.0;
+      elipse.angle = 0.0;
+    }
+    return elipse;
+  }
+
+
+
+  /***************************************************************************
+  Implementació de les classes per al càlcul de característiques sobre el blob
+
+  Implementation of the helper classes to perform operations on blobs
+  **************************************************************************/
+
+  /**
+  - FUNCIÓ: Moment
+  - FUNCIONALITAT: Calcula el moment pq del blob
+  - RESULTAT:
+  - retorna el moment pq especificat o 0 si el moment no està implementat
+  - RESTRICCIONS:
+  - Implementats els moments pq: 00, 01, 10, 20, 02
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: Moment
+  - FUNCTIONALITY: Calculates the pq moment of the blob
+  - PARAMETERS:
+  - RESULT:
+  - returns the pq moment or 0 if the moment it is not implemented
+  - RESTRICTIONS:
+  - Currently, only implemented the 00, 01, 10, 20, 02 pq moments
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 20-07-2004.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetMoment::operator()(const CBlob &blob) const
+  {
+    //Moment 00
+    if ((m_p == 0) && (m_q == 0))
+      return blob.Area();
+
+    //Moment 10
+    if ((m_p == 1) && (m_q == 0))
+      return blob.SumX();
+
+    //Moment 01
+    if ((m_p == 0) && (m_q == 1))
+      return blob.SumY();
+
+    //Moment 20
+    if ((m_p == 2) && (m_q == 0))
+      return blob.SumXX();
+
+    //Moment 02
+    if ((m_p == 0) && (m_q == 2))
+      return blob.SumYY();
+
+    return 0;
+  }
+
+  /**
+  - FUNCIÓ: HullPerimeter
+  - FUNCIONALITAT: Calcula la longitud del perimetre convex del blob.
+  Fa servir la funció d'OpenCV cvConvexHull2 per a
+  calcular el perimetre convex.
+
+  - PARÀMETRES:
+  - RESULTAT:
+  - retorna la longitud del perímetre convex del blob. Si el blob no té coordenades
+  associades retorna el perímetre normal del blob.
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobGetHullPerimeter
+  - FUNCTIONALITY: Calculates the convex hull perimeter of the blob
+  - PARAMETERS:
+  - RESULT:
+  - returns the convex hull perimeter of the blob or the perimeter if the
+  blob edges could not be retrieved
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetHullPerimeter::operator()(const CBlob &blob) const
+  {
+    if (blob.Edges() != NULL && blob.Edges()->total > 0)
+    {
+      CvSeq *hull = cvConvexHull2(blob.Edges(), 0, CV_CLOCKWISE, 1);
+      return fabs(cvArcLength(hull, CV_WHOLE_SEQ, 1));
+    }
+    return blob.Perimeter();
+  }
+
+  double CBlobGetHullArea::operator()(const CBlob &blob) const
+  {
+    if (blob.Edges() != NULL && blob.Edges()->total > 0)
+    {
+      CvSeq *hull = cvConvexHull2(blob.Edges(), 0, CV_CLOCKWISE, 1);
+      return fabs(cvContourArea(hull));
+    }
+    return blob.Perimeter();
+  }
+
+  /**
+  - FUNCIÓ: MinX_at_MinY
+  - FUNCIONALITAT: Calcula el valor MinX a MinY.
+  - PARÀMETRES:
+  - blob: blob del que volem calcular el valor
+  - RESULTAT:
+  - retorna la X minima en la Y minima.
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobGetMinXatMinY
+  - FUNCTIONALITY: Calculates the minimum X on the minimum Y
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetMinXatMinY::operator()(const CBlob &blob) const
+  {
+    double MinX_at_MinY = LONG_MAX;
+
+    CvSeqReader reader;
+    CvPoint edgeactual;
+
+    cvStartReadSeq(blob.Edges(), &reader);
+
+    for (int j = 0; j < blob.Edges()->total; j++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      if ((edgeactual.y == blob.MinY()) && (edgeactual.x < MinX_at_MinY))
+      {
+        MinX_at_MinY = edgeactual.x;
+      }
+    }
+
+    return MinX_at_MinY;
+  }
+
+  /**
+  - FUNCIÓ: MinY_at_MaxX
+  - FUNCIONALITAT: Calcula el valor MinX a MaxX.
+  - PARÀMETRES:
+  - blob: blob del que volem calcular el valor
+  - RESULTAT:
+  - retorna la Y minima en la X maxima.
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobGetMinXatMinY
+  - FUNCTIONALITY: Calculates the minimum Y on the maximum X
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetMinYatMaxX::operator()(const CBlob &blob) const
+  {
+    double MinY_at_MaxX = LONG_MAX;
+
+    CvSeqReader reader;
+    CvPoint edgeactual;
+
+    cvStartReadSeq(blob.Edges(), &reader);
+
+    for (int j = 0; j < blob.Edges()->total; j++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      if ((edgeactual.x == blob.MaxX()) && (edgeactual.y < MinY_at_MaxX))
+      {
+        MinY_at_MaxX = edgeactual.y;
+      }
+    }
+
+    return MinY_at_MaxX;
+  }
+
+  /**
+  - FUNCIÓ: MaxX_at_MaxY
+  - FUNCIONALITAT: Calcula el valor MaxX a MaxY.
+  - PARÀMETRES:
+  - blob: blob del que volem calcular el valor
+  - RESULTAT:
+  - retorna la X maxima en la Y maxima.
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobGetMaxXatMaxY
+  - FUNCTIONALITY: Calculates the maximum X on the maximum Y
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetMaxXatMaxY::operator()(const CBlob &blob) const
+  {
+    double MaxX_at_MaxY = LONG_MIN;
+
+    CvSeqReader reader;
+    CvPoint edgeactual;
+
+    cvStartReadSeq(blob.Edges(), &reader);
+
+    for (int j = 0; j<blob.Edges()->total; j++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      if ((edgeactual.y == blob.MaxY()) && (edgeactual.x > MaxX_at_MaxY))
+      {
+        MaxX_at_MaxY = edgeactual.x;
+      }
+    }
+
+    return MaxX_at_MaxY;
+  }
+
+  /**
+  - FUNCIÓ: MaxY_at_MinX
+  - FUNCIONALITAT: Calcula el valor MaxY a MinX.
+  - PARÀMETRES:
+  - blob: blob del que volem calcular el valor
+  - RESULTAT:
+  - retorna la Y maxima en la X minima.
+  - RESTRICCIONS:
+  - AUTOR: Ricard Borràs
+  - DATA DE CREACIÓ: 20-07-2004.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: CBlobGetMaxYatMinX
+  - FUNCTIONALITY: Calculates the maximum Y on the minimum X
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetMaxYatMinX::operator()(const CBlob &blob) const
+  {
+    double MaxY_at_MinX = LONG_MIN;
+
+    CvSeqReader reader;
+    CvPoint edgeactual;
+
+    cvStartReadSeq(blob.Edges(), &reader);
+
+    for (int j = 0; j<blob.Edges()->total; j++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      if ((edgeactual.x == blob.MinY()) && (edgeactual.y > MaxY_at_MinX))
+      {
+        MaxY_at_MinX = edgeactual.y;
+      }
+    }
+
+    return MaxY_at_MinX;
+  }
+
+  /**
+  Retorna l'elongació del blob (longitud/amplada)
+  */
+  /**
+  - FUNCTION: CBlobGetElongation
+  - FUNCTIONALITY: Calculates the elongation of the blob ( length/breadth )
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - See below to see how the lenght and the breadth are aproximated
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetElongation::operator()(const CBlob &blob) const
+  {
+    double ampladaC, longitudC, amplada, longitud;
+
+    ampladaC = (double)(blob.Perimeter() + sqrt(pow(blob.Perimeter(), 2) - 16 * blob.Area())) / 4;
+    if (ampladaC <= 0.0) return 0;
+    longitudC = (double)blob.Area() / ampladaC;
+
+    longitud = MAX(longitudC, ampladaC);
+    amplada = MIN(longitudC, ampladaC);
+
+    return (double)longitud / amplada;
+  }
+
+  /**
+  Retorna la compacitat del blob
+  */
+  /**
+  - FUNCTION: CBlobGetCompactness
+  - FUNCTIONALITY: Calculates the compactness of the blob
+  ( maximum for circle shaped blobs, minimum for the rest)
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetCompactness::operator()(const CBlob &blob) const
+  {
+    if (blob.Area() != 0.0)
+      return (double)pow(blob.Perimeter(), 2) / (4 * CV_PI*blob.Area());
+    else
+      return 0.0;
+  }
+
+  /**
+  Retorna la rugositat del blob
+  */
+  /**
+  - FUNCTION: CBlobGetRoughness
+  - FUNCTIONALITY: Calculates the roughness of the blob
+  ( ratio between perimeter and convex hull perimeter)
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetRoughness::operator()(const CBlob &blob) const
+  {
+    CBlobGetHullPerimeter getHullPerimeter = CBlobGetHullPerimeter();
+
+    double hullPerimeter = getHullPerimeter(blob);
+
+    if (hullPerimeter != 0.0)
+      return blob.Perimeter() / hullPerimeter;//HullPerimeter();
+
+    return 0.0;
+  }
+
+  /**
+  Retorna la longitud del blob
+  */
+  /**
+  - FUNCTION: CBlobGetLength
+  - FUNCTIONALITY: Calculates the lenght of the blob (the biggest axis of the blob)
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - The lenght is an aproximation to the real lenght
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetLength::operator()(const CBlob &blob) const
+  {
+    double ampladaC, longitudC;
+    double tmp;
+
+    tmp = blob.Perimeter()*blob.Perimeter() - 16 * blob.Area();
+
+    if (tmp > 0.0)
+      ampladaC = (double)(blob.Perimeter() + sqrt(tmp)) / 4;
+    // error intrínsec en els càlculs de l'àrea i el perímetre 
+    else
+      ampladaC = (double)(blob.Perimeter()) / 4;
+
+    if (ampladaC <= 0.0) return 0;
+    longitudC = (double)blob.Area() / ampladaC;
+
+    return MAX(longitudC, ampladaC);
+  }
+
+  /**
+  Retorna l'amplada del blob
+  */
+  /**
+  - FUNCTION: CBlobGetBreadth
+  - FUNCTIONALITY: Calculates the breadth of the blob (the smallest axis of the blob)
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - The breadth is an aproximation to the real breadth
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetBreadth::operator()(const CBlob &blob) const
+  {
+    double ampladaC, longitudC;
+    double tmp;
+
+    tmp = blob.Perimeter()*blob.Perimeter() - 16 * blob.Area();
+
+    if (tmp > 0.0)
+      ampladaC = (double)(blob.Perimeter() + sqrt(tmp)) / 4;
+    // error intrínsec en els càlculs de l'àrea i el perímetre 
+    else
+      ampladaC = (double)(blob.Perimeter()) / 4;
+
+    if (ampladaC <= 0.0) return 0;
+    longitudC = (double)blob.Area() / ampladaC;
+
+    return MIN(longitudC, ampladaC);
+  }
+
+  /**
+  Calcula la distància entre un punt i el centre del blob
+  */
+  /**
+  - FUNCTION: CBlobGetDistanceFromPoint
+  - FUNCTIONALITY: Calculates the euclidean distance between the blob center and
+  the point specified in the constructor
+  - PARAMETERS:
+  - RESULT:
+  - RESTRICTIONS:
+  - AUTHOR: Ricard Borràs
+  - CREATION DATE: 25-05-2005.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetDistanceFromPoint::operator()(const CBlob &blob) const
+  {
+    double xmitjana, ymitjana;
+    CBlobGetXCenter getXCenter;
+    CBlobGetYCenter getYCenter;
+
+    xmitjana = m_x - getXCenter(blob);
+    ymitjana = m_y - getYCenter(blob);
+
+    return sqrt((xmitjana*xmitjana) + (ymitjana*ymitjana));
+  }
+
+  /**
+  - FUNCIÓ: BlobGetXYInside
+  - FUNCIONALITAT: Calcula si un punt cau dins de la capsa rectangular
+  del blob
+  - RESULTAT:
+  - retorna 1 si hi està; 0 si no
+  - RESTRICCIONS:
+  - AUTOR: Francesc Pinyol Margalef
+  - DATA DE CREACIÓ: 16-01-2006.
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  /**
+  - FUNCTION: BlobGetXYInside
+  - FUNCTIONALITY: Calculates whether a point is inside the
+  rectangular bounding box of a blob
+  - PARAMETERS:
+  - RESULT:
+  - returns 1 if it is inside; o if not
+  - RESTRICTIONS:
+  - AUTHOR: Francesc Pinyol Margalef
+  - CREATION DATE: 16-01-2006.
+  - MODIFICATION: Date. Author. Description.
+  */
+  double CBlobGetXYInside::operator()(const CBlob &blob) const
+  {
+    if (blob.Edges() == NULL || blob.Edges()->total == 0) return 0.0;
+
+    // passem els punts del blob a un vector de punts de les STL
+    CvSeqReader reader;
+    CBlob::vectorPunts vectorEdges;
+    CBlob::vectorPunts::iterator itEdges, itEdgesSeguent;
+    CvPoint edgeactual;
+    bool dinsBlob;
+
+    // agafem tots els punts amb la mateixa y que l'actual
+    cvStartReadSeq(blob.Edges(), &reader);
+
+    for (int i = 0; i < blob.Edges()->total; i++)
+    {
+      CV_READ_SEQ_ELEM(edgeactual, reader);
+      if (edgeactual.y == m_p.y)
+        vectorEdges.push_back(edgeactual);
+    }
+
+    if (vectorEdges.empty()) return 0.0;
+
+    // ordenem el vector per les Y's i les X's d'esquerra a dreta
+    std::sort(vectorEdges.begin(), vectorEdges.end(), CBlob::comparaCvPoint());
+
+    // recorrem el punts del blob de la mateixa fila que el punt d'entrada
+    // i mirem si la X del punt d'entrada està entre dos coordenades "plenes"
+    // del blob
+    itEdges = vectorEdges.begin();
+    itEdgesSeguent = vectorEdges.begin() + 1;
+    dinsBlob = true;
+
+    while (itEdges != (vectorEdges.end() - 1))
+    {
+      if ((*itEdges).x <= m_p.x && (*itEdgesSeguent).x >= m_p.x && dinsBlob)
+      {
+        vectorEdges.clear();
+        return 1.0;
+      }
+
+      ++itEdges;
+      ++itEdgesSeguent;
+      dinsBlob = !dinsBlob;
+    }
+
+    vectorEdges.clear();
+    return 0.0;
+  }
+
+#ifdef BLOB_OBJECT_FACTORY
+
+  /**
+  - FUNCIÓ: RegistraTotsOperadors
+  - FUNCIONALITAT: Registrar tots els operadors definits a blob.h
+  - PARÀMETRES:
+  - fabricaOperadorsBlob: fàbrica on es registraran els operadors
+  - RESULTAT:
+  - Modifica l'objecte fabricaOperadorsBlob
+  - RESTRICCIONS:
+  - Només es registraran els operadors de blob.h. Si se'n volen afegir, cal afegir-los amb 
+  el mètode Register de la fàbrica.
+  - AUTOR: rborras
+  - DATA DE CREACIÓ: 2006/05/18
+  - MODIFICACIÓ: Data. Autor. Descripció.
+  */
+  void RegistraTotsOperadors( t_OperadorBlobFactory &fabricaOperadorsBlob )
+  {
+    // blob shape
+    fabricaOperadorsBlob.Register( CBlobGetArea().GetNom(), Type2Type<CBlobGetArea>());
+    fabricaOperadorsBlob.Register( CBlobGetBreadth().GetNom(), Type2Type<CBlobGetBreadth>());
+    fabricaOperadorsBlob.Register( CBlobGetCompactness().GetNom(), Type2Type<CBlobGetCompactness>());
+    fabricaOperadorsBlob.Register( CBlobGetElongation().GetNom(), Type2Type<CBlobGetElongation>());
+    fabricaOperadorsBlob.Register( CBlobGetExterior().GetNom(), Type2Type<CBlobGetExterior>());
+    fabricaOperadorsBlob.Register( CBlobGetLength().GetNom(), Type2Type<CBlobGetLength>());
+    fabricaOperadorsBlob.Register( CBlobGetPerimeter().GetNom(), Type2Type<CBlobGetPerimeter>());
+    fabricaOperadorsBlob.Register( CBlobGetRoughness().GetNom(), Type2Type<CBlobGetRoughness>());
+
+    // extern pixels
+    fabricaOperadorsBlob.Register( CBlobGetExternPerimeterRatio().GetNom(), Type2Type<CBlobGetExternPerimeterRatio>());
+    fabricaOperadorsBlob.Register( CBlobGetExternHullPerimeterRatio().GetNom(), Type2Type<CBlobGetExternHullPerimeterRatio>());
+    fabricaOperadorsBlob.Register( CBlobGetExternPerimeter().GetNom(), Type2Type<CBlobGetExternPerimeter>());
+
+
+    // hull 
+    fabricaOperadorsBlob.Register( CBlobGetHullPerimeter().GetNom(), Type2Type<CBlobGetHullPerimeter>());
+    fabricaOperadorsBlob.Register( CBlobGetHullArea().GetNom(), Type2Type<CBlobGetHullArea>());
+
+
+    // elipse info
+    fabricaOperadorsBlob.Register( CBlobGetMajorAxisLength().GetNom(), Type2Type<CBlobGetMajorAxisLength>());
+    fabricaOperadorsBlob.Register( CBlobGetMinorAxisLength().GetNom(), Type2Type<CBlobGetMinorAxisLength>());
+    fabricaOperadorsBlob.Register( CBlobGetAxisRatio().GetNom(), Type2Type<CBlobGetAxisRatio>());
+    fabricaOperadorsBlob.Register( CBlobGetOrientation().GetNom(), Type2Type<CBlobGetOrientation>());
+    fabricaOperadorsBlob.Register( CBlobGetOrientationCos().GetNom(), Type2Type<CBlobGetOrientationCos>());
+    fabricaOperadorsBlob.Register( CBlobGetAreaElipseRatio().GetNom(), Type2Type<CBlobGetAreaElipseRatio>());
+
+    // min an max
+    fabricaOperadorsBlob.Register( CBlobGetMaxX().GetNom(), Type2Type<CBlobGetMaxX>());
+    fabricaOperadorsBlob.Register( CBlobGetMaxY().GetNom(), Type2Type<CBlobGetMaxY>());
+    fabricaOperadorsBlob.Register( CBlobGetMinX().GetNom(), Type2Type<CBlobGetMinX>());
+    fabricaOperadorsBlob.Register( CBlobGetMinY().GetNom(), Type2Type<CBlobGetMinY>());
+
+    fabricaOperadorsBlob.Register( CBlobGetMaxXatMaxY().GetNom(), Type2Type<CBlobGetMaxXatMaxY>());
+    fabricaOperadorsBlob.Register( CBlobGetMaxYatMinX().GetNom(), Type2Type<CBlobGetMaxYatMinX>());
+    fabricaOperadorsBlob.Register( CBlobGetMinXatMinY().GetNom(), Type2Type<CBlobGetMinXatMinY>());
+    fabricaOperadorsBlob.Register( CBlobGetMinYatMaxX().GetNom(), Type2Type<CBlobGetMinYatMaxX>());
+
+    // grey level stats
+    fabricaOperadorsBlob.Register( CBlobGetMean().GetNom(), Type2Type<CBlobGetMean>());
+    fabricaOperadorsBlob.Register( CBlobGetStdDev().GetNom(), Type2Type<CBlobGetStdDev>());
+
+    // coordinate info
+    fabricaOperadorsBlob.Register( CBlobGetXYInside().GetNom(), Type2Type<CBlobGetXYInside>());
+    fabricaOperadorsBlob.Register( CBlobGetDiffY().GetNom(), Type2Type<CBlobGetDiffY>());
+    fabricaOperadorsBlob.Register( CBlobGetDiffX().GetNom(), Type2Type<CBlobGetDiffX>());
+    fabricaOperadorsBlob.Register( CBlobGetXCenter().GetNom(), Type2Type<CBlobGetXCenter>());
+    fabricaOperadorsBlob.Register( CBlobGetYCenter().GetNom(), Type2Type<CBlobGetYCenter>());
+    fabricaOperadorsBlob.Register( CBlobGetDistanceFromPoint().GetNom(), Type2Type<CBlobGetDistanceFromPoint>());
+
+    // moments
+    fabricaOperadorsBlob.Register( CBlobGetMoment().GetNom(), Type2Type<CBlobGetMoment>());
+
+  }
+
+#endif
+
+}
+

--- a/package_bgs/jmo/blob.h
+++ b/package_bgs/jmo/blob.h
@@ -1,0 +1,846 @@
+/*
+This file is part of BGSLibrary.
+
+BGSLibrary is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+BGSLibrary is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with BGSLibrary.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* --- --- ---
+* Copyright (C) 2008--2010 Idiap Research Institute (.....@idiap.ch)
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. The name of the author may not be used to endorse or promote products
+*    derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************
+Blob.h
+
+FUNCIONALITAT: Definició de la classe CBlob
+AUTOR: Inspecta S.L.
+MODIFICACIONS (Modificació, Autor, Data):
+
+FUNCTIONALITY: Definition of the CBlob class and some helper classes to perform
+some calculations on it
+AUTHOR: Inspecta S.L.
+MODIFICATIONS (Modification, Author, Date):
+
+**************************************************************************/
+
+//! Disable warnings referred to 255 character truncation for the std:map
+//#pragma warning( disable : 4786 ) 
+
+#ifndef CBLOB_INSPECTA_INCLUDED
+#define CBLOB_INSPECTA_INCLUDED
+
+//#include "cxcore.h"
+#include "BlobLibraryConfiguration.h"
+#include <functional>
+#include <vector>
+#include <algorithm>
+#include "OpenCvLegacyIncludes.h"
+//! Factor de conversió de graus a radians
+#define DEGREE2RAD		(CV_PI / 180.0)
+
+namespace Blob
+{
+
+  /**
+  Classe que representa un blob, entés com un conjunt de pixels del
+  mateix color contigus en una imatge binaritzada.
+
+  Class to represent a blob, a group of connected pixels in a binary image
+  */
+  class CBlob
+  {
+  public:
+    //! Constructor estàndard
+    //! Standard constructor
+    CBlob();
+    //! Constructor de còpia
+    //! Copy constructor
+    CBlob(const CBlob &src);
+    CBlob(const CBlob *src);
+
+    //! Destructor estàndard
+    //! Standard Destructor
+    ~CBlob();
+
+    //! Operador d'assignació
+    //! Assigment operator
+    CBlob& operator=(const CBlob &src);
+
+    //! Indica si el blob està buit ( no té cap info associada )
+    //! Shows if the blob has associated information
+    bool IsEmpty() const
+    {
+      return (area == 0.0 && perimeter == 0.0);
+    };
+
+    //! Neteja les cantonades del blob
+    //! Clears the edges of the blob
+    void ClearEdges();
+    //! Copia les cantonades del blob a un altre (les afegeix al destí)
+    //! Adds the blob edges to another blob
+    void CopyEdges(CBlob &destination) const;
+    //! Retorna el poligon convex del blob
+    //! Calculates the convex hull of the blob
+    bool GetConvexHull(CvSeq **dst) const;
+    //! Calcula l'elipse que s'adapta als vèrtexs del blob
+    //! Fits an ellipse to the blob edges
+    CvBox2D GetEllipse() const;
+
+    //! Pinta l'interior d'un blob d'un color determinat
+    //! Paints the blob in an image
+    void FillBlob(IplImage *imatge, CvScalar color, int offsetX = 0, int offsetY = 0) const;
+
+    //! Funcions GET sobre els valors dels blobs
+    //! Get functions
+
+    inline int Label() const	{ return etiqueta; }
+    inline int Parent() const	{ return parent; }
+    inline double Area() const { return area; }
+    inline double Perimeter() const { return perimeter; }
+    inline double ExternPerimeter() const { return externPerimeter; }
+    inline int	  Exterior() const { return exterior; }
+    inline double Mean() const { return mean; }
+    inline double StdDev() const { return stddev; }
+    inline double MinX() const { return minx; }
+    inline double MinY() const { return miny; }
+    inline double MaxX() const { return maxx; }
+    inline double MaxY() const { return maxy; }
+    inline CvSeq *Edges() const { return edges; }
+    inline double SumX() const { return sumx; }
+    inline double SumY() const { return sumy; }
+    inline double SumXX() const { return sumxx; }
+    inline double SumYY() const { return sumyy; }
+    inline double SumXY() const { return sumxy; }
+
+    //! etiqueta del blob
+    //! label of the blob
+    int etiqueta;
+    //! flag per indicar si es exterior o no
+    //! true for extern blobs
+    int exterior;
+    //! area del blob
+    //! Blob area
+    double area;
+    //! perimetre del blob
+    //! Blob perimeter
+    double perimeter;
+    //! quantitat de perimetre del blob extern
+    //! amount of blob perimeter which is exterior
+    double externPerimeter;
+    //! etiqueta del blob pare
+    //! label of the parent blob
+    int parent;
+    //! moments
+    double sumx;
+    double sumy;
+    double sumxx;
+    double sumyy;
+    double sumxy;
+    //! Bounding rect
+    double minx;
+    double maxx;
+    double miny;
+    double maxy;
+
+    //! mitjana
+    //! mean of the grey scale values of the blob pixels
+    double mean;
+    //! desviació standard
+    //! standard deviation of the grey scale values of the blob pixels
+    double stddev;
+
+    //! àrea de memòria on es desaran els punts de contorn del blob
+    //! storage which contains the edges of the blob
+    CvMemStorage *m_storage;
+    //!	Sequència de punts del contorn del blob
+    //! Sequence with the edges of the blob
+    CvSeq *edges;
+
+
+    //! Point datatype for plotting (FillBlob)
+    typedef std::vector<CvPoint> vectorPunts;
+
+    //! Helper class to compare two CvPoints (for sorting in FillBlob)
+    struct comparaCvPoint : public std::binary_function<CvPoint, CvPoint, bool>
+    {
+      //! Definim que un punt és menor com més amunt a la dreta estigui
+      bool operator()(CvPoint a, CvPoint b)
+      {
+        if (a.y == b.y)
+          return a.x < b.x;
+        else
+          return a.y < b.y;
+      }
+    };
+  };
+
+
+
+  /**************************************************************************
+  Definició de les classes per a fer operacions sobre els blobs
+
+  Helper classes to perform operations on blobs
+  **************************************************************************/
+
+
+  //! Classe d'on derivarem totes les operacions sobre els blobs
+  //! Interface to derive all blob operations
+  class COperadorBlob
+  {
+  public:
+    virtual ~COperadorBlob(){};
+
+    //! Aplica l'operació al blob
+    virtual double operator()(const CBlob &blob) const = 0;
+    //! Obté el nom de l'operador
+    virtual const char *GetNom() const = 0;
+
+    operator COperadorBlob*() const
+    {
+      return (COperadorBlob*)this;
+    }
+  };
+
+  typedef COperadorBlob funcio_calculBlob;
+
+#ifdef BLOB_OBJECT_FACTORY
+  /**
+  Funció per comparar dos identificadors dins de la fàbrica de COperadorBlobs
+  */
+  struct functorComparacioIdOperador
+  {
+    bool operator()(const char* s1, const char* s2) const
+    {
+      return strcmp(s1, s2) < 0;
+    }
+  };
+
+  //! Definition of Object factory type for COperadorBlob objects
+  typedef ObjectFactory<COperadorBlob, const char *, functorComparacioIdOperador > t_OperadorBlobFactory;
+
+  //! Funció global per a registrar tots els operadors definits a blob.h
+  void RegistraTotsOperadors( t_OperadorBlobFactory &fabricaOperadorsBlob );
+
+#endif
+
+  //! Classe per calcular l'àrea d'un blob
+  //! Class to get the area of a blob
+  class CBlobGetArea : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.Area();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetArea";
+    }
+  };
+
+  //! Classe per calcular el perimetre d'un blob
+  //! Class to get the perimeter of a blob
+  class CBlobGetPerimeter : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.Perimeter();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetPerimeter";
+    }
+  };
+
+  //! Classe que diu si un blob és extern o no
+  //! Class to get the extern flag of a blob
+  class CBlobGetExterior : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.Exterior();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetExterior";
+    }
+  };
+
+  //! Classe per calcular la mitjana de nivells de gris d'un blob
+  //! Class to get the mean grey level of a blob
+  class CBlobGetMean : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.Mean();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMean";
+    }
+  };
+
+  //! Classe per calcular la desviació estàndard dels nivells de gris d'un blob
+  //! Class to get the standard deviation of the grey level values of a blob
+  class CBlobGetStdDev : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.StdDev();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetStdDev";
+    }
+  };
+
+  //! Classe per calcular la compacitat d'un blob
+  //! Class to calculate the compactness of a blob
+  class CBlobGetCompactness : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetCompactness";
+    }
+  };
+
+  //! Classe per calcular la longitud d'un blob
+  //! Class to calculate the length of a blob
+  class CBlobGetLength : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetLength";
+    }
+  };
+
+  //! Classe per calcular l'amplada d'un blob
+  //! Class to calculate the breadth of a blob
+  class CBlobGetBreadth : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetBreadth";
+    }
+  };
+
+  //! Classe per calcular la diferència en X del blob
+  class CBlobGetDiffX : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.maxx - blob.minx;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetDiffX";
+    }
+  };
+
+  //! Classe per calcular la diferència en X del blob
+  class CBlobGetDiffY : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.maxy - blob.miny;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetDiffY";
+    }
+  };
+
+  //! Classe per calcular el moment PQ del blob
+  //! Class to calculate the P,Q moment of a blob
+  class CBlobGetMoment : public COperadorBlob
+  {
+  public:
+    //! Constructor estàndard
+    //! Standard constructor (gets the 00 moment)
+    CBlobGetMoment()
+    {
+      m_p = m_q = 0;
+    }
+    //! Constructor: indiquem el moment p,q a calcular
+    //! Constructor: gets the PQ moment
+    CBlobGetMoment(int p, int q)
+    {
+      m_p = p;
+      m_q = q;
+    };
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetMoment";
+    }
+
+  private:
+    //! moment que volem calcular
+    int m_p, m_q;
+  };
+
+  //! Classe per calcular el perimetre del poligon convex d'un blob
+  //! Class to calculate the convex hull perimeter of a blob
+  class CBlobGetHullPerimeter : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetHullPerimeter";
+    }
+  };
+
+  //! Classe per calcular l'àrea del poligon convex d'un blob
+  //! Class to calculate the convex hull area of a blob
+  class CBlobGetHullArea : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetHullArea";
+    }
+  };
+
+  //! Classe per calcular la x minima en la y minima
+  //! Class to calculate the minimum x on the minimum y
+  class CBlobGetMinXatMinY : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetMinXatMinY";
+    }
+  };
+
+  //! Classe per calcular la y minima en la x maxima
+  //! Class to calculate the minimum y on the maximum x
+  class CBlobGetMinYatMaxX : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetMinYatMaxX";
+    }
+  };
+
+  //! Classe per calcular la x maxima en la y maxima
+  //! Class to calculate the maximum x on the maximum y
+  class CBlobGetMaxXatMaxY : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetMaxXatMaxY";
+    }
+  };
+
+  //! Classe per calcular la y maxima en la x minima
+  //! Class to calculate the maximum y on the minimum y
+  class CBlobGetMaxYatMinX : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetMaxYatMinX";
+    }
+  };
+
+  //! Classe per a calcular la x mínima
+  //! Class to get the minimum x
+  class CBlobGetMinX : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MinX();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMinX";
+    }
+  };
+
+  //! Classe per a calcular la x màxima
+  //! Class to get the maximum x
+  class CBlobGetMaxX : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MaxX();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMaxX";
+    }
+  };
+
+  //! Classe per a calcular la y mínima
+  //! Class to get the minimum y
+  class CBlobGetMinY : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MinY();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMinY";
+    }
+  };
+
+  //! Classe per a calcular la y màxima
+  //! Class to get the maximum y
+  class CBlobGetMaxY : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MaxY();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMax";
+    }
+  };
+
+
+  //! Classe per calcular l'elongacio d'un blob
+  //! Class to calculate the elongation of the blob
+  class CBlobGetElongation : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetElongation";
+    }
+  };
+
+  //! Classe per calcular la rugositat d'un blob
+  //! Class to calculate the roughness of the blob
+  class CBlobGetRoughness : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetRoughness";
+    }
+  };
+
+  //! Classe per calcular la distància entre el centre del blob i un punt donat
+  //! Class to calculate the euclidean distance between the center of a blob and a given point
+  class CBlobGetDistanceFromPoint : public COperadorBlob
+  {
+  public:
+    //! Standard constructor (distance to point 0,0)
+    CBlobGetDistanceFromPoint()
+    {
+      m_x = m_y = 0.0;
+    }
+    //! Constructor (distance to point x,y)
+    CBlobGetDistanceFromPoint(const double x, const double y)
+    {
+      m_x = x;
+      m_y = y;
+    }
+
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetDistanceFromPoint";
+    }
+
+  private:
+    // coordenades del punt on volem calcular la distància
+    double m_x, m_y;
+  };
+
+  //! Classe per calcular el nombre de pixels externs d'un blob
+  //! Class to get the number of extern pixels of a blob
+  class CBlobGetExternPerimeter : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.ExternPerimeter();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetExternPerimeter";
+    }
+  };
+
+  //! Classe per calcular el ratio entre el perimetre i nombre pixels externs
+  //! valors propers a 0 indiquen que la majoria del blob és intern
+  //! valors propers a 1 indiquen que la majoria del blob és extern
+  //! Class to calculate the ratio between the perimeter and the number of extern pixels
+  class CBlobGetExternPerimeterRatio : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      if (blob.Perimeter() != 0)
+        return blob.ExternPerimeter() / blob.Perimeter();
+      else
+        return blob.ExternPerimeter();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetExternPerimeterRatio";
+    }
+  };
+
+  //! Classe per calcular el ratio entre el perimetre convex i nombre pixels externs
+  //! valors propers a 0 indiquen que la majoria del blob és intern
+  //! valors propers a 1 indiquen que la majoria del blob és extern
+  //! Class to calculate the ratio between the perimeter and the number of extern pixels
+  class CBlobGetExternHullPerimeterRatio : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CBlobGetHullPerimeter getHullPerimeter;
+      double hullPerimeter;
+
+      if ((hullPerimeter = getHullPerimeter(blob)) != 0)
+        return blob.ExternPerimeter() / hullPerimeter;
+      else
+        return blob.ExternPerimeter();
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetExternHullPerimeterRatio";
+    }
+  };
+
+  //! Classe per calcular el centre en el eix X d'un blob
+  //! Class to calculate the center in the X direction
+  class CBlobGetXCenter : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MinX() + ((blob.MaxX() - blob.MinX()) / 2.0);
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetXCenter";
+    }
+  };
+
+  //! Classe per calcular el centre en el eix Y d'un blob
+  //! Class to calculate the center in the Y direction
+  class CBlobGetYCenter : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      return blob.MinY() + ((blob.MaxY() - blob.MinY()) / 2.0);
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetYCenter";
+    }
+  };
+
+  //! Classe per calcular la longitud de l'eix major d'un blob
+  //! Class to calculate the length of the major axis of the ellipse that fits the blob edges
+  class CBlobGetMajorAxisLength : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CvBox2D elipse = blob.GetEllipse();
+
+      return elipse.size.width;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMajorAxisLength";
+    }
+  };
+
+  //! Classe per calcular el ratio entre l'area de la elipse i la de la taca
+  //! Class 
+  class CBlobGetAreaElipseRatio : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      if (blob.Area() == 0.0) return 0.0;
+
+      CvBox2D elipse = blob.GetEllipse();
+      double ratioAreaElipseAreaTaca = ((elipse.size.width / 2.0)
+        *
+        (elipse.size.height / 2.0)
+        *CV_PI
+        )
+        /
+        blob.Area();
+
+      return ratioAreaElipseAreaTaca;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetAreaElipseRatio";
+    }
+  };
+
+  //! Classe per calcular la longitud de l'eix menor d'un blob
+  //! Class to calculate the length of the minor axis of the ellipse that fits the blob edges
+  class CBlobGetMinorAxisLength : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CvBox2D elipse = blob.GetEllipse();
+
+      return elipse.size.height;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetMinorAxisLength";
+    }
+  };
+
+  //! Classe per calcular l'orientació de l'ellipse del blob en radians
+  //! Class to calculate the orientation of the ellipse that fits the blob edges in radians
+  class CBlobGetOrientation : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CvBox2D elipse = blob.GetEllipse();
+
+      if (elipse.angle > 180.0)
+        return ((elipse.angle - 180.0)* DEGREE2RAD);
+      else
+        return (elipse.angle * DEGREE2RAD);
+
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetOrientation";
+    }
+  };
+
+  //! Classe per calcular el cosinus de l'orientació de l'ellipse del blob
+  //! Class to calculate the cosinus of the orientation of the ellipse that fits the blob edges
+  class CBlobGetOrientationCos : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CBlobGetOrientation getOrientation;
+      return fabs(cos(getOrientation(blob)));
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetOrientationCos";
+    }
+  };
+
+
+  //! Classe per calcular el ratio entre l'eix major i menor de la el·lipse
+  //! Class to calculate the ratio between both axes of the ellipse
+  class CBlobGetAxisRatio : public COperadorBlob
+  {
+  public:
+    double operator()(const CBlob &blob) const
+    {
+      CvBox2D elipse = blob.GetEllipse();
+
+      return elipse.size.height / elipse.size.width;
+    }
+    const char *GetNom() const
+    {
+      return "CBlobGetAxisRatio";
+    }
+  };
+
+
+  //! Classe per calcular si un punt cau dins del blob
+  //! Class to calculate whether a point is inside a blob
+  class CBlobGetXYInside : public COperadorBlob
+  {
+  public:
+    //! Constructor estàndard
+    //! Standard constructor
+    CBlobGetXYInside()
+    {
+      m_p = cvPoint(0, 0);
+    }
+    //! Constructor: indiquem el punt
+    //! Constructor: sets the point
+    CBlobGetXYInside(CvPoint p)
+    {
+      m_p = p;
+    };
+    double operator()(const CBlob &blob) const;
+    const char *GetNom() const
+    {
+      return "CBlobGetXYInside";
+    }
+
+  private:
+    //! punt que considerem
+    //! point to be considered
+    CvPoint m_p;
+  };
+
+}
+
+#endif //CBLOB_INSPECTA_INCLUDED
+


### PR DESCRIPTION
Summary of changes compared to the master version to make it compatible with OpenCV 3.1:

* Centralized OpenCV includes to one header which only includes the OpenCV headers that are actually used (because some includes were causing trouble)
* Changed `cvCopyImage` to `cvCopy`
* Changed `cv::Mat(legacyImage)` to `cv::cvarrToMat(legacyImage)`

I only added back the `jmo` directory to `package_bgs`, assuming some other code would have to be changed to enable it in the demo apps.
