### PR TITLE
Fix a crash in the IndependentMultimodal algorithm during setup. The …

### DIFF
--- a/package_bgs/IMBS/IMBS.cpp
+++ b/package_bgs/IMBS/IMBS.cpp
@@ -54,6 +54,9 @@ BackgroundSubtractorIMBS::BackgroundSubtractorIMBS()
   tau_h = 40;
   minArea = 30.;
   nframes = 0;
+  bgBins = NULL;
+  bgModel = NULL;
+  persistenceMap = NULL;
   persistencePeriod = samplingPeriod*numSamples / 3.;//ms
 
   initial_tick_count = (double)getTickCount();
@@ -96,6 +99,9 @@ BackgroundSubtractorIMBS::BackgroundSubtractorIMBS(
   this->tau_h = tau_h;
   this->minArea = minArea;
   nframes = 0;
+  bgBins = NULL;
+  bgModel = NULL;
+  persistenceMap = NULL;
 
   if (fps == 0.)
     initial_tick_count = (double)getTickCount();

--- a/package_bgs/IMBS/IMBS.cpp
+++ b/package_bgs/IMBS/IMBS.cpp
@@ -53,6 +53,7 @@ BackgroundSubtractorIMBS::BackgroundSubtractorIMBS()
   tau_s = 60;
   tau_h = 40;
   minArea = 30.;
+  nframes = 0;
   persistencePeriod = samplingPeriod*numSamples / 3.;//ms
 
   initial_tick_count = (double)getTickCount();
@@ -94,6 +95,7 @@ BackgroundSubtractorIMBS::BackgroundSubtractorIMBS(
   this->tau_s = tau_s;
   this->tau_h = tau_h;
   this->minArea = minArea;
+  nframes = 0;
 
   if (fps == 0.)
     initial_tick_count = (double)getTickCount();


### PR DESCRIPTION
Fix a crash in the IndependentMultimodal algorithm during setup. The nframes member variable is not initialized, which means that occasionally the initialize() function is not called when the first frame is processed.

* package_bgs/IMBS/IMBS.cpp
  (BackgroundSubtractorIMBS): Initialize nframes to 0.
