### PR TITLE
Independent Multimodal algorithm: assert that a frame is larger than 0x0 pixels

### DIFF
--- a/package_bgs/IMBS/IMBS.cpp
+++ b/package_bgs/IMBS/IMBS.cpp
@@ -184,6 +184,8 @@ void BackgroundSubtractorIMBS::apply(InputArray _frame, OutputArray _fgmask, dou
 
   CV_Assert(frame.depth() == CV_8U);
   CV_Assert(frame.channels() == 3);
+  CV_Assert(frame.size().width > 0);
+  CV_Assert(frame.size().height > 0);
 
   bool needToInitialize = nframes == 0 || frame.type() != frameType;
   if (needToInitialize) {


### PR DESCRIPTION
This replaces a crash with clearer error message.

* package_bgs/IMBS/IMBS.cpp
  (BackgroundSubtractorIMBS::apply): assert that size > 0.