### PR TITLE
Update  bgslibrary.pro

### DIFF
--- a/gui_qt/bgslibrary_gui.pro
+++ b/gui_qt/bgslibrary_gui.pro
@@ -129,7 +129,7 @@ SOURCES += bgslibrary_gui.cpp\
     ../package_bgs/VuMeter.cpp \
     ../package_bgs/WeightedMovingMean.cpp \
     ../package_bgs/WeightedMovingVariance.cpp \
-    ../package_bgs/_template_/amber/amber.c \
+    ../package_bgs/_template_/amber/amber.cpp \
     ../package_bgs/CodeBook.cpp
 
 HEADERS  += mainwindow.h \


### PR DESCRIPTION
update bgslibrary.pro  according to change of file
amber.c is removed 
amber.cpp is needed for building gui_qt