### PR TITLE
Edited and Tested: Added CMake Target Export to the Installation Step for easy Integrati…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(bgslibrary)
+project(bgslibrary VERSION 3.0.0)
 
 include(CheckCXXCompilerFlag)
 
@@ -296,13 +296,51 @@ if(UNIX AND BGS_PYTHON_SUPPORT)
 endif()
 
 if(NOT BGS_PYTHON_ONLY)
+  include(GNUInstallDirs)
+  set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/BGSLibrary)
+  target_include_directories(bgslibrary_core
+    PUBLIC
+        $<INSTALL_INTERFACE:include>)
+
+
   install(TARGETS bgslibrary_core
     bgslibrary
+    EXPORT bgslibrary_core-targets
     RUNTIME DESTINATION bin COMPONENT app
     LIBRARY DESTINATION lib COMPONENT runtime
     ARCHIVE DESTINATION lib COMPONENT runtime
     #PUBLIC_HEADER DESTINATION include/bgslibrary COMPONENT dev
     FRAMEWORK DESTINATION "/Library/Frameworks"
+  )
+  set_target_properties(bgslibrary_core PROPERTIES EXPORT_NAME BGSLibrary)
+
+  install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(EXPORT bgslibrary_core-targets
+    FILE
+      BGSLibraryTargets.cmake
+    NAMESPACE
+      BGSLibrary::
+    DESTINATION
+      ${INSTALL_CONFIGDIR}
+  )
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/BGSLibraryConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+  )
+
+  configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake-modules/BGSLibraryConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/BGSLibraryConfig.cmake
+    INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+  )
+
+  install(FILES
+    ${CMAKE_CURRENT_LIST_DIR}/cmake-modules/FindOpenCV.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/BGSLibraryConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/BGSLibraryConfigVersion.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
   )
 
   if(UNIX)

--- a/cmake-modules/BGSLibraryConfig.cmake.in
+++ b/cmake-modules/BGSLibraryConfig.cmake.in
@@ -1,0 +1,13 @@
+get_filename_component(BGSLibrary_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${BGSLibrary_CMAKE_DIR})
+
+find_package(OpenCV 2.3.1 REQUIRED )
+list(REMOVE_AT CMAKE_MODULE_PATH -1)
+
+if(NOT TARGET BGSLibrary::BGSLibrary)
+    include("${BGSLibrary_CMAKE_DIR}/BGSLibraryTargets.cmake")
+endif()
+
+set(BGSLibrary_LIBRARIES BGSLibrary::BGSLibrary)


### PR DESCRIPTION
…on of BGSLibrary in user projects.

usage:
1.) Install bgslibrary with Cmake
2.) Include bgslibrary in your project:
cmake_minimum_required(VERSION 3.5)
find_package(BGSLibrary 3.0.0 REQUIRED)
add_executable(BackgroundSubtractionTester main.cpp)
target_link_libraries(BackgroundSubtractionTester BGSLibrary::BGSLibrary)

Now edited and tested under Ubuntu 18.04 and Windows 10.