### PR TITLE
Add support to Visual Studio generators in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ class BuildCMakeExt(build_ext, object):
         cmake_cache_file = os.path.join(self.build_temp, 'CMakeCache.txt')
         with open(cmake_cache_file, 'r') as cmake_cache:
             for line in cmake_cache.readlines():
-                if line.find('CMAKE_GENERATOR:INTERNAL') != -1:
+                if line.find('CMAKE_GENERATOR:') != -1:
                     generator = line[line.find('=') + 1:].strip()
         
         self.announce("Building binaries", level=3)


### PR DESCRIPTION
As issue #199 said, install directly by invoking
```
python setup.py build
```
in Windows will end up with 'Unknown switch' error, due to mismatch between the build args between
different tool chains.

A automatical build args selector is implemented by identifying the generator based on the content of
{BUILD_DIR}/CMakeCache.txt.