### PR TITLE
gui: add zero-padding to numbers when saving frames

### DIFF
--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -434,19 +434,19 @@ void MainWindow::processFrame(const cv::Mat &cv_frame)
   if (ui->checkBox_save_im->isChecked())
   {
     QString out_im_path = ui->lineEdit_out_in->text();
-    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber_aux) + ".png");
+    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber_aux).rightJustified(5, '0') + ".png");
     cv::imwrite(out_im_file.toStdString(), cv_frame);
   }
   if (ui->checkBox_save_fg->isChecked())
   {
     QString out_im_path = ui->lineEdit_out_fg->text();
-    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber_aux) + ".png");
+    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber_aux).rightJustified(5, '0') + ".png");
     cv::imwrite(out_im_file.toStdString(), cv_fg);
   }
   if (ui->checkBox_save_bg->isChecked())
   {
     QString out_im_path = ui->lineEdit_out_bg->text();
-    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber) + ".png");
+    QString out_im_file = QDir(out_im_path).filePath(QString::number(frameNumber).rightJustified(5, '0') + ".png");
     cv::imwrite(out_im_file.toStdString(), cv_bg);
   }
 }


### PR DESCRIPTION
This avoids having an output folder looking like this:
```

10.png
11.png
12.png
13.png
14.png
15.png
16.png
17.png
18.png
19.png
1.png
20.png
21.png
22.png
23.png
24.png
25.png
26.png
27.png
28.png
29.png
2.png
30.png
31.png
32.png
33.png
34.png
35.png
36.png
37.png
38.png
39.png
3.png
40.png
41.png
42.png
...
```

Now it rather looks like this:
```
00001.png
00002.png
00003.png
00004.png
00005.png
00006.png
00007.png
00008.png
00009.png
00010.png
00011.png
00012.png
00013.png
00014.png
00015.png
00016.png
00017.png
00018.png
00019.png
00020.png
00021.png
00022.png
00023.png
00024.png
00025.png
00026.png
00027.png
00028.png
00029.png
00030.png
00031.png
00032.png
00033.png
00034.png
00035.png
00036.png
00037.png
00038.png
00039.png
00040.png
00041.png
00042.png
...
```