### PR TITLE
ci: skip CI on docs-only changes (paths-ignore)

### DIFF
--- a/.github/workflows/cmake_autobuild_ubuntu_ocv3416.yml
+++ b/.github/workflows/cmake_autobuild_ubuntu_ocv3416.yml
@@ -3,6 +3,12 @@ name: CMake autobuild on Ubuntu + OpenCV 3.4.16
 on:
   pull_request:
     branches: [ "master" ]
+    # Skip CI for docs-only changes (markdown/docs/help/LICENSE) to save runner time.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'help/**'
+      - 'LICENSE'
   # push:
   #   branches: [ "master" ]
 

--- a/.github/workflows/cmake_autobuild_ubuntu_ocv347.yml
+++ b/.github/workflows/cmake_autobuild_ubuntu_ocv347.yml
@@ -3,6 +3,12 @@ name: CMake autobuild on Ubuntu + OpenCV 3.4.7
 on:
   pull_request:
     branches: [ "master" ]
+    # Skip CI for docs-only changes (markdown/docs/help/LICENSE) to save runner time.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'help/**'
+      - 'LICENSE'
   # push:
   #   branches: [ "master" ]
 

--- a/.github/workflows/cmake_autobuild_ubuntu_ocv460.yml
+++ b/.github/workflows/cmake_autobuild_ubuntu_ocv460.yml
@@ -3,6 +3,12 @@ name: CMake autobuild on Ubuntu + OpenCV 4.6.0
 on:
   pull_request:
     branches: [ "master" ]
+    # Skip CI for docs-only changes (markdown/docs/help/LICENSE) to save runner time.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'help/**'
+      - 'LICENSE'
   # push:
   #   branches: [ "master" ]
 

--- a/.github/workflows/pixi_golden_matrix.yml
+++ b/.github/workflows/pixi_golden_matrix.yml
@@ -16,6 +16,12 @@ name: Pixi golden-master matrix (OS×arch × OpenCV 4)
 on:
   pull_request:
     branches: [ "master" ]
+    # Skip CI for docs-only changes (markdown/docs/help/LICENSE) to save runner time.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'help/**'
+      - 'LICENSE'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## What

Add `paths-ignore` to the `pull_request` trigger of the CI workflows so **documentation-only PRs don't run the full build/test matrix**.

Applied to all four PR-triggered workflows:
- `cmake_autobuild_ubuntu_ocv347.yml`, `cmake_autobuild_ubuntu_ocv3416.yml`, `cmake_autobuild_ubuntu_ocv460.yml`
- `pixi_golden_matrix.yml`

Ignored paths:
```yaml
paths-ignore:
  - '**/*.md'
  - 'docs/**'
  - 'help/**'
  - 'LICENSE'
```

## Why it's safe

- `master` has **no branch protection / required status checks**, so a docs-only PR that skips these workflows is **not** blocked waiting for a check to report (the usual `paths-ignore` + required-check trap doesn't apply here).
- `paths-ignore` only skips a run when **every** changed file matches, so mixed PRs (code + docs) still run CI in full.
- `workflow_dispatch` on the matrix is unaffected — manual runs always work.

Motivated by #236 (a README-only PR) triggering the whole matrix unnecessarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
