### PR TITLE
fix(python): install pybgs on Windows by dropping UNIX-only gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(NOT BGS_PYTHON_ONLY)
   # set_target_properties(bgslibrary PROPERTIES OUTPUT_NAME bgs)
 endif()
 
-if(UNIX AND BGS_PYTHON_SUPPORT)
+if(BGS_PYTHON_SUPPORT)
   execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
       import sysconfig, os


### PR DESCRIPTION
## Summary
- `install(TARGETS bgs_python ...)` was wrapped in `if(UNIX AND BGS_PYTHON_SUPPORT)`, so on Windows `cmake --install build_py` silently skipped copying `pybgs.<tag>.pyd` into `site-packages`. The build succeeded, the install reported no errors, but `import pybgs` failed with `ModuleNotFoundError`.
- The `sysconfig.get_path('platlib', vars={'base':'', 'platbase':''})` call already produces a relative path that works on every platform (`Lib/site-packages` on Windows, `lib/pythonX.Y/site-packages` on POSIX). Dropping `UNIX AND` is the entire fix.

## Repro (before)
```
pixi run install_python   # finishes clean, pybgs.pyd NOT installed
python -c "import pybgs"  # ModuleNotFoundError: No module named 'pybgs'
```

## After
```
-- The bgslibrary python package will be installed at: Lib\site-packages
-- Installing: .../.pixi/envs/default/Lib/site-packages/pybgs.cp312-win_amd64.pyd
$ python -c "import pybgs; print(pybgs.__file__)"
OK: ...\.pixi\envs\default\Lib\site-packages\pybgs.cp312-win_amd64.pyd
```

## Test plan
- [x] Windows / pixi env / Python 3.12: `pixi run clean_python && pixi run install_python && python -c "import pybgs"` succeeds
- [ ] Linux: confirm `install_python` still drops the `.so` in `lib/pythonX.Y/site-packages` (no behaviour change expected — the gate was the only thing removed)
- [ ] macOS: same as Linux